### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -11,8 +11,21 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
+    function escapeHTML(str) {
+        return str.replace(/[&<>"']/g, function (m) {
+            switch (m) {
+                case '&': return '&amp;';
+                case '<': return '&lt;';
+                case '>': return '&gt;';
+                case '"': return '&quot;';
+                case "'": return '&#39;';
+                default: return m;
+            }
+        });
+    }
+
     function validateDomain(domain) {
-        resultsContainer.innerHTML = '<p>Validating DNSSEC for ' + domain + '...</p>';
+        resultsContainer.innerHTML = '<p>Validating DNSSEC for ' + escapeHTML(domain) + '...</p>';
         
         fetch('/api/validate/' + encodeURIComponent(domain))
             .then(response => response.json())


### PR DESCRIPTION
Potential fix for [https://github.com/BondIT-ApS/dnssec-validator/security/code-scanning/2](https://github.com/BondIT-ApS/dnssec-validator/security/code-scanning/2)

To fix this problem, we need to ensure that any user-supplied input is properly escaped before being inserted into the DOM as HTML. The best way to do this is to escape any special HTML characters in the `domain` variable before interpolating it into the HTML string. This can be done by creating a helper function (e.g., `escapeHTML`) that replaces characters like `<`, `>`, `&`, `"`, and `'` with their corresponding HTML entities. The fix should be applied specifically to the use of `domain` in the string on line 15. The helper function should be defined within the same file, above its first use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
