### PR TITLE
CI: nightly and monthly Docker builds; latest follows monthly

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,7 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Image (PR and tags)
 
 on:
   push:
-    branches:
-      - master
     tags:
       - 'v*'
   pull_request:
@@ -27,8 +25,8 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to Docker Hub
-      if: github.event_name != 'pull_request'
+    - name: Log in to Docker Hub (for tags only)
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -40,14 +38,8 @@ jobs:
       with:
         images: ${{ env.REGISTRY_IMAGE }}
         tags: |
-          # Latest tag for master branch
-          type=raw,value=latest,enable={{is_default_branch}}
-          # Version tags for releases
+          # Version tags for releases (vX.Y or vX.Y.Z)
           type=ref,event=tag
-          # Date-based tag for master builds
-          type=raw,value={{date 'YYYY-MM-DD'}},enable={{is_default_branch}}
-          # Commit SHA for tracking
-          type=sha,prefix={{branch}}-,suffix=-{{date 'YYYY-MM-DD'}},enable={{is_default_branch}}
           # PR tags for pull requests
           type=ref,event=pr
 
@@ -56,14 +48,14 @@ jobs:
       with:
         context: .
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-    - name: Update Docker Hub Description
-      if: github.ref == 'refs/heads/master'
+    - name: Update Docker Hub Description (on version tags)
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,0 +1,75 @@
+name: monthly
+
+on:
+  schedule:
+    - cron: "5 2 * * *"  # 02:05 UTC daily
+  workflow_dispatch:
+
+jobs:
+  monthly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      IMAGE: maboni82/dnssec-validator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Decide if today is first weekday of month (UTC)
+        id: when
+        shell: bash
+        run: |
+          FIRST_OF_MONTH=$(date -u +'%Y-%m-01')
+          DOW=$(date -u -d "$FIRST_OF_MONTH" +%u)  # 1..7 Mon..Sun
+          case "$DOW" in
+            6) FIRST_WEEKDAY=$(date -u -d "$FIRST_OF_MONTH +2 days" +%Y-%m-%d) ;;
+            7) FIRST_WEEKDAY=$(date -u -d "$FIRST_OF_MONTH +1 day" +%Y-%m-%d) ;;
+            *) FIRST_WEEKDAY=$(date -u -d "$FIRST_OF_MONTH" +%Y-%m-%d) ;;
+          esac
+          TODAY=$(date -u +%Y-%m-%d)
+          echo "FIRST_WEEKDAY=$FIRST_WEEKDAY" >> "$GITHUB_OUTPUT"
+          echo "TODAY=$TODAY" >> "$GITHUB_OUTPUT"
+          if [[ "$TODAY" == "$FIRST_WEEKDAY" ]]; then
+            echo "RUN=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "RUN=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set tags
+        if: steps.when.outputs.RUN == 'true'
+        id: vars
+        run: |
+          MONTH_UTC=$(date -u +'%Y.%m')
+          echo "MONTH_UTC=${MONTH_UTC}" >> "$GITHUB_OUTPUT"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.when.outputs.RUN == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU
+        if: steps.when.outputs.RUN == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        if: steps.when.outputs.RUN == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push monthly image
+        if: steps.when.outputs.RUN == 'true'
+        run: |
+          TAG_MONTH="v-${{ steps.vars.outputs.MONTH_UTC }}"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t "$IMAGE:$TAG_MONTH" \
+            -t "$IMAGE:latest" \
+            --push \
+            .
+

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -2,7 +2,11 @@ name: monthly
 
 on:
   schedule:
-    - cron: "5 2 * * *"  # 02:05 UTC daily
+    # 21:12 local time in Europe/Copenhagen, accounting for DST:
+    # - Apr–Oct (CEST, UTC+2) => 19:12 UTC
+    - cron: "12 19 * 4-10 *"
+    # - Nov–Mar (CET, UTC+1) => 20:12 UTC
+    - cron: "12 20 * 11,12,1-3 *"
   workflow_dispatch:
 
 jobs:
@@ -12,24 +16,25 @@ jobs:
       contents: read
     env:
       IMAGE: maboni82/dnssec-validator
+      TZ: Europe/Copenhagen
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: master
 
-      - name: Decide if today is first weekday of month (UTC)
+      - name: Decide if today is first weekday of month (Europe/Copenhagen)
         id: when
         shell: bash
         run: |
-          FIRST_OF_MONTH=$(date -u +'%Y-%m-01')
-          DOW=$(date -u -d "$FIRST_OF_MONTH" +%u)  # 1..7 Mon..Sun
+          FIRST_OF_MONTH=$(date +'%Y-%m-01')
+          DOW=$(date -d "$FIRST_OF_MONTH" +%u)  # 1..7 Mon..Sun
           case "$DOW" in
-            6) FIRST_WEEKDAY=$(date -u -d "$FIRST_OF_MONTH +2 days" +%Y-%m-%d) ;;
-            7) FIRST_WEEKDAY=$(date -u -d "$FIRST_OF_MONTH +1 day" +%Y-%m-%d) ;;
-            *) FIRST_WEEKDAY=$(date -u -d "$FIRST_OF_MONTH" +%Y-%m-%d) ;;
+            6) FIRST_WEEKDAY=$(date -d "$FIRST_OF_MONTH +2 days" +%Y-%m-%d) ;;
+            7) FIRST_WEEKDAY=$(date -d "$FIRST_OF_MONTH +1 day" +%Y-%m-%d) ;;
+            *) FIRST_WEEKDAY=$(date -d "$FIRST_OF_MONTH" +%Y-%m-%d) ;;
           esac
-          TODAY=$(date -u +%Y-%m-%d)
+          TODAY=$(date +%Y-%m-%d)
           echo "FIRST_WEEKDAY=$FIRST_WEEKDAY" >> "$GITHUB_OUTPUT"
           echo "TODAY=$TODAY" >> "$GITHUB_OUTPUT"
           if [[ "$TODAY" == "$FIRST_WEEKDAY" ]]; then
@@ -42,8 +47,8 @@ jobs:
         if: steps.when.outputs.RUN == 'true'
         id: vars
         run: |
-          MONTH_UTC=$(date -u +'%Y.%m')
-          echo "MONTH_UTC=${MONTH_UTC}" >> "$GITHUB_OUTPUT"
+          MONTH_LOCAL=$(date +'%Y.%m')
+          echo "MONTH_LOCAL=${MONTH_LOCAL}" >> "$GITHUB_OUTPUT"
           SHORT_SHA="${GITHUB_SHA::7}"
           echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
@@ -65,7 +70,7 @@ jobs:
       - name: Build and push monthly image
         if: steps.when.outputs.RUN == 'true'
         run: |
-          TAG_MONTH="v-${{ steps.vars.outputs.MONTH_UTC }}"
+          TAG_MONTH="v-${{ steps.vars.outputs.MONTH_LOCAL }}"
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             -t "$IMAGE:$TAG_MONTH" \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,11 @@ name: nightly
 
 on:
   schedule:
-    - cron: "0 2 * * *"  # 02:00 UTC daily
+    # 21:12 local time in Europe/Copenhagen, accounting for DST:
+    # - Apr–Oct (CEST, UTC+2) => 19:12 UTC
+    - cron: "12 19 * 4-10 *"
+    # - Nov–Mar (CET, UTC+1) => 20:12 UTC
+    - cron: "12 20 * 11,12,1-3 *"
   workflow_dispatch:
 
 jobs:
@@ -12,6 +16,7 @@ jobs:
       contents: read
     env:
       IMAGE: maboni82/dnssec-validator
+      TZ: Europe/Copenhagen
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,8 +26,8 @@ jobs:
       - name: Set tags
         id: vars
         run: |
-          DATE_UTC=$(date -u +'%Y.%m.%d')
-          echo "DATE_UTC=${DATE_UTC}" >> "$GITHUB_OUTPUT"
+          DATE_LOCAL=$(date +'%Y.%m.%d')
+          echo "DATE_LOCAL=${DATE_LOCAL}" >> "$GITHUB_OUTPUT"
           SHORT_SHA="${GITHUB_SHA::7}"
           echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
@@ -40,7 +45,7 @@ jobs:
 
       - name: Build and push nightly image
         run: |
-          TAG1="dev-${{ steps.vars.outputs.DATE_UTC }}"
+          TAG1="dev-${{ steps.vars.outputs.DATE_LOCAL }}"
           TAG2="${{ steps.vars.outputs.SHORT_SHA }}"
           docker buildx build \
             --platform linux/amd64,linux/arm64 \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,51 @@
+name: nightly
+
+on:
+  schedule:
+    - cron: "0 2 * * *"  # 02:00 UTC daily
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      IMAGE: maboni82/dnssec-validator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set tags
+        id: vars
+        run: |
+          DATE_UTC=$(date -u +'%Y.%m.%d')
+          echo "DATE_UTC=${DATE_UTC}" >> "$GITHUB_OUTPUT"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push nightly image
+        run: |
+          TAG1="dev-${{ steps.vars.outputs.DATE_UTC }}"
+          TAG2="${{ steps.vars.outputs.SHORT_SHA }}"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t "$IMAGE:$TAG1" \
+            -t "$IMAGE:$TAG2" \
+            --push \
+            .
+


### PR DESCRIPTION
Implements https://github.com/BondIT-ApS/dnssec-validator/issues/58\n\nChanges:\n- Add .github/workflows/nightly.yml to publish dev-YYYY.MM.DD + short SHA nightly from master.\n- Add .github/workflows/monthly.yml to publish v-YYYY.MM and latest on the first weekday of each month.\n- Refactor .github/workflows/docker-publish.yml to only push on tags (PRs still build without push) and stop publishing latest/date tags on master merges.\n\nNotes:\n- Uses existing secrets DOCKER_USERNAME/DOCKER_PASSWORD and repo maboni82/dnssec-validator.\n- Schedules run in UTC (02:00 nightly, 02:05 monthly).\n- Monthly job computes first weekday in UTC.\n\nPlease review; happy to tweak times/tag formats or branch ref (master vs main).