### PR TITLE
CI: Add workflow testing and debugging features

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -8,6 +8,12 @@ on:
     # - Nov–Mar (CET, UTC+1) => 20:12 UTC
     - cron: "12 20 * 11,12,1-3 *"
   workflow_dispatch:
+    inputs:
+      force_run:
+        description: 'Force monthly build (ignore first-weekday check)'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   monthly:
@@ -35,11 +41,21 @@ jobs:
             *) FIRST_WEEKDAY=$(date -d "$FIRST_OF_MONTH" +%Y-%m-%d) ;;
           esac
           TODAY=$(date +%Y-%m-%d)
+          
+          echo "📅 Checking monthly build conditions:"
+          echo "   Today: $TODAY ($(date +'%A'))"
+          echo "   First of month: $FIRST_OF_MONTH (day-of-week: $DOW)"
+          echo "   First weekday: $FIRST_WEEKDAY"
+          echo "   Force run: ${{ inputs.force_run }}"
+          
           echo "FIRST_WEEKDAY=$FIRST_WEEKDAY" >> "$GITHUB_OUTPUT"
           echo "TODAY=$TODAY" >> "$GITHUB_OUTPUT"
-          if [[ "$TODAY" == "$FIRST_WEEKDAY" ]]; then
+          
+          if [[ "${{ inputs.force_run }}" == "true" ]] || [[ "$TODAY" == "$FIRST_WEEKDAY" ]]; then
+            echo "✅ Running monthly build!"
             echo "RUN=true" >> "$GITHUB_OUTPUT"
           else
+            echo "⏸️ Skipping - not first weekday and not forced"
             echo "RUN=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,8 +27,13 @@ jobs:
         id: vars
         run: |
           DATE_LOCAL=$(date +'%Y.%m.%d')
-          echo "DATE_LOCAL=${DATE_LOCAL}" >> "$GITHUB_OUTPUT"
           SHORT_SHA="${GITHUB_SHA::7}"
+          
+          echo "🌙 Building nightly image:"
+          echo "   Date: $DATE_LOCAL ($(date +'%A, %B %d, %Y'))"
+          echo "   Tags: dev-$DATE_LOCAL, $SHORT_SHA"
+          
+          echo "DATE_LOCAL=${DATE_LOCAL}" >> "$GITHUB_OUTPUT"
           echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,84 @@
+name: test-build
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_type:
+        description: 'Type of build to test'
+        required: true
+        default: 'nightly'
+        type: choice
+        options:
+        - nightly
+        - monthly
+      push_images:
+        description: 'Actually push to Docker Hub (otherwise just build)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      IMAGE: maboni82/dnssec-validator
+      TZ: Europe/Copenhagen
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set test tags
+        id: vars
+        run: |
+          DATE_LOCAL=$(date +'%Y.%m.%d')
+          MONTH_LOCAL=$(date +'%Y.%m')
+          SHORT_SHA="${GITHUB_SHA::7}"
+          
+          if [[ "${{ inputs.test_type }}" == "nightly" ]]; then
+            TAG1="test-dev-${DATE_LOCAL}"
+            TAG2="test-${SHORT_SHA}"
+            echo "🧪 Testing NIGHTLY build:"
+          else
+            TAG1="test-v-${MONTH_LOCAL}"
+            TAG2="test-latest"
+            echo "🧪 Testing MONTHLY build:"
+          fi
+          
+          echo "   Tags: $TAG1, $TAG2"
+          echo "   Push to registry: ${{ inputs.push_images }}"
+          
+          echo "TAG1=${TAG1}" >> "$GITHUB_OUTPUT"
+          echo "TAG2=${TAG2}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: inputs.push_images
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and optionally push test image
+        run: |
+          TAG1="${{ steps.vars.outputs.TAG1 }}"
+          TAG2="${{ steps.vars.outputs.TAG2 }}"
+          
+          BUILD_ARGS="--platform linux/amd64,linux/arm64"
+          BUILD_ARGS="$BUILD_ARGS -t $IMAGE:$TAG1"
+          BUILD_ARGS="$BUILD_ARGS -t $IMAGE:$TAG2"
+          
+          if [[ "${{ inputs.push_images }}" == "true" ]]; then
+            BUILD_ARGS="$BUILD_ARGS --push"
+            echo "🚀 Building and pushing to Docker Hub..."
+          else
+            echo "🔨 Building locally (no push)..."
+          fi
+          
+          docker buildx build $BUILD_ARGS .


### PR DESCRIPTION
Fixes issues identified in #58 and https://hub.docker.com/r/maboni82/dnssec-validator\n\n## Problems addressed:\n- Old `master-*` tags on Docker Hub were from the previous docker-publish workflow\n- Monthly workflow hasn't run yet (next scheduled: Sept 2nd, first weekday)\n- Need ability to test workflows manually\n\n## Changes:\n- **Monthly workflow**: Add `force_run` input to bypass first-weekday check for testing\n- **Debug output**: Both workflows now show clear info about dates, tags, and conditions\n- **Test workflow**: New `test-build` workflow for safe testing without affecting production tags\n\n## How to test:\n1. Go to Actions → monthly → Run workflow → check "Force monthly build"\n2. This will create `v-2025.08` and update `latest` tags immediately\n3. Use `test-build` workflow to verify builds work without pushing\n\n## Next steps:\n- Run monthly workflow manually to get current `v-2025.08` and `latest`\n- Old `master-*` tags can be cleaned up manually on Docker Hub if desired\n- Nightly will start running automatically at 21:12 CET/CEST