### PR TITLE
Add configurable BondIT attribution footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,52 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 - [ ] [Implement caching for faster responses](https://github.com/BondIT-ApS/dnssec-validator/issues/36)
 - [ ] [Add support for internationalized domain names (IDN)](https://github.com/BondIT-ApS/dnssec-validator/issues/37)
 
+## 🎨 BondIT Attribution Footer
+
+The DNSSEC Validator includes an optional attribution footer that shows gratitude to BondIT ApS for building and maintaining the tool. The footer appears at the bottom of all web pages.
+
+### Footer Content
+
+When enabled, the footer displays:
+- **Built with ❤️ by BondIT ApS** with link to [https://bondit.dk](https://bondit.dk)
+- **View on GitHub** link to the repository
+
+### Configuration
+
+The attribution footer is **enabled by default** but can be disabled using an environment variable:
+
+```bash
+# Show attribution footer (default)
+SHOW_BONDIT_ATTRIBUTION=true
+
+# Hide attribution footer
+SHOW_BONDIT_ATTRIBUTION=false
+```
+
+The environment variable accepts the following values for enabling:
+- `true` (recommended)
+- `1`
+- `yes`
+
+Any other value (including `false`) will disable the footer.
+
+### Docker Compose Example
+
+```yaml
+services:
+  dnssec-validator:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - FLASK_ENV=production
+      - SHOW_BONDIT_ATTRIBUTION=true  # Show footer (default)
+```
+
+### Why Attribution?
+
+We believe in open source and free access to security tools. The optional attribution footer is a simple way to show appreciation for the development and maintenance of this tool. You're free to disable it, but we'd appreciate it if you kept it enabled! 🙏
+
 ## 🛡️ Rate Limiting
 
 The DNSSEC Validator includes comprehensive rate limiting to ensure fair usage and prevent abuse. Rate limits are applied per IP address and are configurable via environment variables.

--- a/app/app.py
+++ b/app/app.py
@@ -168,6 +168,19 @@ logger.debug(f"Structured logging enabled: {is_structured}")
 logger.debug(f"Log file: {os.getenv('LOG_FILE', 'None - console only')}")
 
 
+# BondIT attribution configuration
+def show_attribution():
+    """Check if BondIT attribution footer should be shown"""
+    attribution = os.getenv("SHOW_BONDIT_ATTRIBUTION", "true").lower()
+    return attribution in ["true", "1", "yes"]  # Support true, 1, yes for flexibility
+
+
+@app.context_processor
+def inject_attribution():
+    """Make attribution setting available to all templates"""
+    return {"show_attribution": show_attribution()}
+
+
 # Request logging functionality
 def get_client_ip():
     """Get the real client IP address considering proxies"""

--- a/app/dnssec_validator.py
+++ b/app/dnssec_validator.py
@@ -12,12 +12,7 @@ import dns.query
 import dns.message
 
 from tlsa_validator import TLSAValidator
-from domain_utils import (
-    normalize_domain,
-    is_apex_domain,
-    get_fallback_domains,
-    has_subdomain,
-)
+from domain_utils import get_fallback_domains, has_subdomain
 
 
 class DNSSECValidator:

--- a/app/templates/detailed.html
+++ b/app/templates/detailed.html
@@ -705,5 +705,13 @@
             return colors[status] || '#6c757d';
         }
     </script>
+    
+    {% if show_attribution %}
+    <footer style="text-align: center; padding: 20px 0; margin-top: 40px; color: #6c757d; font-size: 0.9em; border-top: 1px solid #e9ecef;">
+        Built with ❤️ by 
+        <a href="https://bondit.dk" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">BondIT ApS</a> | 
+        <a href="https://github.com/BondIT-ApS/dnssec-validator" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">View on GitHub</a>
+    </footer>
+    {% endif %}
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,5 +35,13 @@
         {% endif %}
     </script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+    
+    {% if show_attribution %}
+    <footer style="text-align: center; padding: 20px 0; margin-top: 40px; color: #6c757d; font-size: 0.9em; border-top: 1px solid #e9ecef;">
+        Built with ❤️ by 
+        <a href="https://bondit.dk" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">BondIT ApS</a> | 
+        <a href="https://github.com/BondIT-ApS/dnssec-validator" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">View on GitHub</a>
+    </footer>
+    {% endif %}
 </body>
 </html>

--- a/app/templates/rate_limit.html
+++ b/app/templates/rate_limit.html
@@ -141,5 +141,13 @@
             }
         }, {{ retry_after * 1000 }});
     </script>
+    
+    {% if show_attribution %}
+    <footer style="text-align: center; padding: 20px 0; margin-top: 40px; color: #6c757d; font-size: 0.9em; border-top: 1px solid #e9ecef;">
+        Built with ❤️ by 
+        <a href="https://bondit.dk" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">BondIT ApS</a> | 
+        <a href="https://github.com/BondIT-ApS/dnssec-validator" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">View on GitHub</a>
+    </footer>
+    {% endif %}
 </body>
 </html>

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -514,5 +514,13 @@
             setInterval(updateAnalytics, 30000);
         });
     </script>
+    
+    {% if show_attribution %}
+    <footer style="text-align: center; padding: 20px 0; margin-top: 40px; color: #6c757d; font-size: 0.9em; border-top: 1px solid #e9ecef;">
+        Built with ❤️ by 
+        <a href="https://bondit.dk" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">BondIT ApS</a> | 
+        <a href="https://github.com/BondIT-ApS/dnssec-validator" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">View on GitHub</a>
+    </footer>
+    {% endif %}
 </body>
 </html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - FLASK_ENV=development
       # Feature flags
       - SHOW_VALIDATION_TLSA_DANE=false       # Enable TLSA/DANE validation display in webapp
+      - SHOW_BONDIT_ATTRIBUTION=true          # Show BondIT attribution footer (default: true)
       # Logging configuration
       - LOG_LEVEL=DEBUG                       # Set log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
       - LOG_FORMAT=standard                   # Format: 'standard' or 'json' for structured logging
@@ -54,9 +55,9 @@ services:
       - INFLUX_ORG=dnssec-validator
       - INFLUX_BUCKET=requests
       # Database management (use these for database operations)
-      - INFLUX_DB_RECREATE=true           # Set to 'true' to recreate database/bucket on startup
+      - INFLUX_DB_RECREATE=false          # Set to 'true' to recreate database/bucket on startup
       - INFLUX_DB_VERSION=v2.1            # Optional schema version for tracking
-      - INFLUX_DB_TRUNCATE=true           # Set to 'true' to truncate all data (DANGEROUS!)
+      - INFLUX_DB_TRUNCATE=false          # Set to 'true' to truncate all data (DANGEROUS!)
       - INFLUX_DB_INIT_WAIT=10            # Seconds to wait for InfluxDB readiness (default: 5)
     volumes:
       - ./app:/app

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,165 @@
+"""Tests for BondIT attribution footer functionality."""
+
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "app"))
+
+import pytest
+from unittest.mock import patch
+
+
+class TestAttributionHelper:
+    """Test the show_attribution helper function."""
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "true"})
+    def test_attribution_enabled_with_true(self):
+        """Test attribution is enabled with 'true' value."""
+        # Need to import after setting env var
+        import importlib
+        import app
+
+        importlib.reload(app)
+        assert app.show_attribution() is True
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "false"})
+    def test_attribution_disabled_with_false(self):
+        """Test attribution is disabled with 'false' value."""
+        import importlib
+        import app
+
+        importlib.reload(app)
+        assert app.show_attribution() is False
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "1"})
+    def test_attribution_enabled_with_one(self):
+        """Test attribution is enabled with '1' value."""
+        import importlib
+        import app
+
+        importlib.reload(app)
+        assert app.show_attribution() is True
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "yes"})
+    def test_attribution_enabled_with_yes(self):
+        """Test attribution is enabled with 'yes' value."""
+        import importlib
+        import app
+
+        importlib.reload(app)
+        assert app.show_attribution() is True
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_attribution_enabled_by_default(self):
+        """Test attribution is enabled by default when env var not set."""
+        # Clear the env var
+        if "SHOW_BONDIT_ATTRIBUTION" in os.environ:
+            del os.environ["SHOW_BONDIT_ATTRIBUTION"]
+
+        import importlib
+        import app
+
+        importlib.reload(app)
+        assert app.show_attribution() is True
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "0"})
+    def test_attribution_disabled_with_zero(self):
+        """Test attribution is disabled with '0' value."""
+        import importlib
+        import app
+
+        importlib.reload(app)
+        assert app.show_attribution() is False
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "no"})
+    def test_attribution_disabled_with_no(self):
+        """Test attribution is disabled with 'no' value."""
+        import importlib
+        import app
+
+        importlib.reload(app)
+        assert app.show_attribution() is False
+
+
+class TestAttributionInTemplates:
+    """Test that attribution is properly injected into templates."""
+
+    def test_context_processor_exists(self):
+        """Test that the context processor is registered."""
+        import app as flask_app
+
+        # Get context processors
+        context_processors = flask_app.app.template_context_processors[None]
+        processor_names = [func.__name__ for func in context_processors]
+
+        assert "inject_attribution" in processor_names
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "true"})
+    def test_context_processor_returns_true(self):
+        """Test context processor returns correct value when enabled."""
+        import importlib
+        import app as flask_app
+
+        importlib.reload(flask_app)
+
+        result = flask_app.inject_attribution()
+        assert "show_attribution" in result
+        assert result["show_attribution"] is True
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "false"})
+    def test_context_processor_returns_false(self):
+        """Test context processor returns correct value when disabled."""
+        import importlib
+        import app as flask_app
+
+        importlib.reload(flask_app)
+
+        result = flask_app.inject_attribution()
+        assert "show_attribution" in result
+        assert result["show_attribution"] is False
+
+
+class TestAttributionIntegration:
+    """Integration tests for attribution footer in web pages."""
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "true"})
+    def test_attribution_in_index_page(self):
+        """Test attribution footer appears in index page when enabled."""
+        import importlib
+        import app as flask_app
+
+        importlib.reload(flask_app)
+
+        client = flask_app.app.test_client()
+        response = client.get("/")
+
+        assert response.status_code == 200
+        html = response.data.decode("utf-8")
+
+        # Check for attribution footer content
+        assert "Built with ❤️ by" in html or "Built with" in html
+        assert "BondIT ApS" in html
+        assert "https://bondit.dk" in html
+        assert "https://github.com/BondIT-ApS/dnssec-validator" in html
+
+    @patch.dict(os.environ, {"SHOW_BONDIT_ATTRIBUTION": "false"})
+    def test_attribution_not_in_index_when_disabled(self):
+        """Test attribution footer does not appear when disabled."""
+        import importlib
+        import app as flask_app
+
+        importlib.reload(flask_app)
+
+        client = flask_app.app.test_client()
+        response = client.get("/")
+
+        assert response.status_code == 200
+        html = response.data.decode("utf-8")
+
+        # Attribution should not be present
+        # Note: We check for the specific footer structure, not just the text
+        # as BondIT may appear elsewhere on the page
+        assert '<footer style="text-align: center' not in html or (
+            "Built with" not in html and "bondit.dk" not in html
+        )

--- a/tests/test_domain_utils.py
+++ b/tests/test_domain_utils.py
@@ -1,4 +1,5 @@
 """Tests for domain_utils module."""
+
 import sys
 import os
 
@@ -6,67 +7,131 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "app"))
 
 import pytest
-from domain_utils import normalize_domain, extract_domain_from_url
+from domain_utils import (
+    extract_domain_from_input,
+    normalize_domain_input,
+    is_valid_domain_format,
+    extract_root_domain,
+    has_subdomain,
+)
 
 
-class TestNormalizeDomain:
-    """Test domain normalization functionality."""
+class TestExtractDomainFromInput:
+    """Test domain extraction from various input formats."""
 
-    def test_normalize_domain_basic(self):
-        """Test basic domain normalization."""
-        assert normalize_domain("EXAMPLE.COM") == "example.com"
-        assert normalize_domain("Example.Com") == "example.com"
-        assert normalize_domain("example.com") == "example.com"
-
-    def test_normalize_domain_with_spaces(self):
-        """Test domain normalization with spaces."""
-        assert normalize_domain(" example.com ") == "example.com"
-        assert normalize_domain("exam ple.com") == "example.com"
-
-    def test_normalize_domain_with_trailing_dot(self):
-        """Test domain normalization with trailing dot."""
-        assert normalize_domain("example.com.") == "example.com"
-
-    def test_normalize_domain_subdomain(self):
-        """Test subdomain normalization."""
-        assert normalize_domain("www.example.com") == "www.example.com"
-        assert normalize_domain("SUB.DOMAIN.example.com") == "sub.domain.example.com"
-
-
-class TestExtractDomainFromUrl:
-    """Test URL domain extraction functionality."""
-
-    def test_extract_domain_from_http_url(self):
+    def test_extract_from_http_url(self):
         """Test extraction from HTTP URLs."""
-        assert extract_domain_from_url("http://example.com") == "example.com"
+        assert extract_domain_from_input("http://example.com") == "example.com"
+        assert extract_domain_from_input("http://example.com/path") == "example.com"
         assert (
-            extract_domain_from_url("http://example.com/path") == "example.com"
-        )
-        assert (
-            extract_domain_from_url("http://example.com/path?query=value")
+            extract_domain_from_input("http://example.com/path?query=value")
             == "example.com"
         )
 
-    def test_extract_domain_from_https_url(self):
+    def test_extract_from_https_url(self):
         """Test extraction from HTTPS URLs."""
-        assert extract_domain_from_url("https://example.com") == "example.com"
+        assert extract_domain_from_input("https://example.com") == "example.com"
         assert (
-            extract_domain_from_url("https://www.example.com/page")
+            extract_domain_from_input("https://www.example.com/page")
             == "www.example.com"
         )
 
-    def test_extract_domain_from_plain_domain(self):
+    def test_extract_from_plain_domain(self):
         """Test extraction from plain domain names."""
-        assert extract_domain_from_url("example.com") == "example.com"
-        assert extract_domain_from_url("www.example.com") == "www.example.com"
+        assert extract_domain_from_input("example.com") == "example.com"
+        assert extract_domain_from_input("www.example.com") == "www.example.com"
 
-    def test_extract_domain_with_port(self):
+    def test_extract_with_port(self):
         """Test extraction with port numbers."""
-        assert extract_domain_from_url("https://example.com:8080") == "example.com"
+        assert extract_domain_from_input("https://example.com:8080") == "example.com"
         assert (
-            extract_domain_from_url("http://example.com:3000/path")
-            == "example.com"
+            extract_domain_from_input("http://example.com:3000/path") == "example.com"
         )
+
+    def test_extract_with_spaces(self):
+        """Test extraction with spaces (should be removed)."""
+        assert extract_domain_from_input(" example.com ") == "example.com"
+        assert extract_domain_from_input("exam ple.com") == "example.com"
+
+    def test_extract_uppercase(self):
+        """Test that domains are lowercased."""
+        assert extract_domain_from_input("EXAMPLE.COM") == "example.com"
+        assert extract_domain_from_input("Example.Com") == "example.com"
+
+
+class TestNormalizeDomainInput:
+    """Test domain input normalization."""
+
+    def test_normalize_plain_domain(self):
+        """Test normalization of plain domain input."""
+        domain, input_type = normalize_domain_input("example.com")
+        assert domain == "example.com"
+        assert input_type == "domain"
+
+    def test_normalize_url_input(self):
+        """Test normalization of URL input."""
+        domain, input_type = normalize_domain_input("https://example.com/path")
+        assert domain == "example.com"
+        assert input_type == "url"
+
+    def test_normalize_invalid_input(self):
+        """Test normalization of invalid input."""
+        domain, input_type = normalize_domain_input("")
+        assert domain is None
+        assert input_type == "invalid"
+
+        domain, input_type = normalize_domain_input("not-a-domain")
+        assert domain is None
+        assert input_type == "invalid"
+
+
+class TestIsValidDomainFormat:
+    """Test domain format validation."""
+
+    def test_valid_domains(self):
+        """Test validation of valid domain formats."""
+        assert is_valid_domain_format("example.com")
+        assert is_valid_domain_format("www.example.com")
+        assert is_valid_domain_format("sub.domain.example.com")
+        assert is_valid_domain_format("example.co.uk")
+
+    def test_invalid_domains(self):
+        """Test validation rejects invalid domain formats."""
+        assert not is_valid_domain_format("")
+        assert not is_valid_domain_format("example")
+        assert not is_valid_domain_format(".example.com")
+        assert not is_valid_domain_format("example.com.")
+        assert not is_valid_domain_format("example..com")
+
+
+class TestExtractRootDomain:
+    """Test root domain extraction."""
+
+    def test_extract_from_subdomain(self):
+        """Test extraction of root domain from subdomains."""
+        assert extract_root_domain("www.example.com") == "example.com"
+        assert extract_root_domain("api.v1.example.com") == "example.com"
+
+    def test_already_root_domain(self):
+        """Test that root domains are returned unchanged."""
+        assert extract_root_domain("example.com") == "example.com"
+
+    def test_two_part_tld(self):
+        """Test handling of two-part TLDs."""
+        assert extract_root_domain("www.example.co.uk") == "example.co.uk"
+
+
+class TestHasSubdomain:
+    """Test subdomain detection."""
+
+    def test_has_subdomain(self):
+        """Test detection of subdomains."""
+        assert has_subdomain("www.example.com")
+        assert has_subdomain("api.example.com")
+
+    def test_no_subdomain(self):
+        """Test detection when no subdomain present."""
+        assert not has_subdomain("example.com")
 
 
 class TestHealthCheck:
@@ -84,7 +149,9 @@ class TestHealthCheck:
         """Test that domain_utils has required functions."""
         import domain_utils
 
-        assert hasattr(domain_utils, "normalize_domain")
-        assert hasattr(domain_utils, "extract_domain_from_url")
-        assert callable(domain_utils.normalize_domain)
-        assert callable(domain_utils.extract_domain_from_url)
+        assert hasattr(domain_utils, "extract_domain_from_input")
+        assert hasattr(domain_utils, "normalize_domain_input")
+        assert hasattr(domain_utils, "is_valid_domain_format")
+        assert callable(domain_utils.extract_domain_from_input)
+        assert callable(domain_utils.normalize_domain_input)
+        assert callable(domain_utils.is_valid_domain_format)


### PR DESCRIPTION
## 🎨 Overview
This PR implements issue #41 - adds an optional attribution footer to show gratitude to BondIT ApS for building and maintaining this tool.

## 🚀 Features
- **Configurable**: Control via `SHOW_BONDIT_ATTRIBUTION` environment variable (default: `true`)
- **Comprehensive**: Appears on all web pages (index, detailed, stats, rate_limit)
- **Professional**: Subtle styling with links to bondit.dk and GitHub repository
- **Flexible**: Can be disabled by setting env var to `false`/`0`/`no`

## 🧪 Testing
- ✅ Added comprehensive test suite (`test_attribution.py`) with 12 new tests
- ✅ Fixed existing tests in `test_domain_utils.py` to use correct function names
- ✅ All 30 tests passing
- ✅ Pylint score: **10.00/10** ✨
- ✅ Tested with Docker and docker-compose - fully functional
- ✅ Code coverage: 68% on domain_utils, 36% on app.py

## 📚 Documentation
- ✅ Updated `README.md` with attribution footer configuration section
- ✅ Updated `WARP.md` with correct testing procedures using venv
- ✅ Updated `docker-compose.yml` with example configuration

## 🔧 Additional Fixes
- Fixed docker-compose database recreation defaults (false instead of true) - prevents worker timeouts
- Removed unused imports from `dnssec_validator.py`
- Updated test approach to use `.venv` for dependencies

## 🖼️ Preview
The footer displays:
> Built with ❤️ by [BondIT ApS](https://bondit.dk) | [View on GitHub](https://github.com/BondIT-ApS/dnssec-validator)

Closes #41