### PR TITLE
Implement Semantic Versioning System (YY.M.PATCH)

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,137 +1,133 @@
-name: monthly
+name: Monthly Release Creation
+
+# Creates monthly production releases (YY.M.0) on the 1st of each month
+# Runs automatically at 04:00 CET (03:00 UTC during summer, 02:00 UTC during winter)
+# Can also be triggered manually
 
 on:
   schedule:
-    # Second Sunday of month at 21:12 local time in Europe/Copenhagen, accounting for DST:
-    # - Apr–Oct (CEST, UTC+2) => 19:12 UTC on Sundays 8-14
-    - cron: "12 19 8-14 4-10 0"
-    # - Nov–Mar (CET, UTC+1) => 20:12 UTC on Sundays 8-14
-    - cron: "12 20 8-14 11,12,1-3 0"
+    - cron: '0 3 1 * *'  # Run at 03:00 UTC on 1st of each month (04:00 CET)
   workflow_dispatch:
-    inputs:
-      force_run:
-        description: 'Force monthly build (ignore second-sunday check)'
-        required: false
-        default: 'false'
-        type: boolean
+
+permissions:
+  contents: write
 
 jobs:
-  monthly:
+  create-monthly-release:
+    name: "🎉 Create Monthly Release"
     runs-on: ubuntu-latest
-    permissions:
-      contents: write  # Need write permission to create Git tags
-    env:
-      IMAGE: maboni82/dnssec-validator
-      TZ: Europe/Copenhagen
+    
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: master
+    - name: "📦 Checkout Repository"
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        
+    - name: "🔢 Determine Release Version"
+      id: version
+      run: |
+        # Get current YY.M
+        CURRENT_MONTH=$(date +"%y.%-m")
+        
+        # Create release version (YY.M.0)
+        RELEASE_VERSION="${CURRENT_MONTH}.0"
+        
+        echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+        
+        echo "📋 Version Information:"
+        echo "   Release Version: $RELEASE_VERSION"
 
-      - name: Decide if today is second Sunday of month (Europe/Copenhagen)
-        id: when
-        shell: bash
-        run: |
-          FIRST_OF_MONTH=$(date +'%Y-%m-01')
-          DOW=$(date -d "$FIRST_OF_MONTH" +%u)  # 1..7 Mon..Sun
-          
-          # Calculate days to first Sunday of the month
-          # If first of month is Sunday (DOW=7), then it's day 1
-          # Otherwise, calculate days needed to reach first Sunday
-          if [[ $DOW -eq 7 ]]; then
-            DAYS_TO_FIRST_SUNDAY=0
-          else
-            DAYS_TO_FIRST_SUNDAY=$((7 - DOW))
-          fi
-          
-          # First Sunday of the month
-          FIRST_SUNDAY=$(date -d "$FIRST_OF_MONTH +$DAYS_TO_FIRST_SUNDAY days" +%Y-%m-%d)
-          
-          # Second Sunday is exactly 7 days after first Sunday
-          SECOND_SUNDAY=$(date -d "$FIRST_SUNDAY +7 days" +%Y-%m-%d)
-          
-          TODAY=$(date +%Y-%m-%d)
-          
-          echo "📅 Checking monthly build conditions:"
-          echo "   Today: $TODAY ($(date +'%A'))"
-          echo "   First of month: $FIRST_OF_MONTH (day-of-week: $DOW)"
-          echo "   First Sunday: $FIRST_SUNDAY"
-          echo "   Second Sunday: $SECOND_SUNDAY"
-          echo "   Force run: ${{ inputs.force_run }}"
-          
-          echo "SECOND_SUNDAY=$SECOND_SUNDAY" >> "$GITHUB_OUTPUT"
-          echo "TODAY=$TODAY" >> "$GITHUB_OUTPUT"
-          
-          if [[ "${{ inputs.force_run }}" == "true" ]] || [[ "$TODAY" == "$SECOND_SUNDAY" ]]; then
-            echo "✅ Running monthly build!"
-            echo "RUN=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "⏸️ Skipping - not second Sunday and not forced"
-            echo "RUN=false" >> "$GITHUB_OUTPUT"
-          fi
+    - name: "🏷️ Create Release Tag"
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        
+        # Check if tag already exists
+        if git tag -l | grep -q "^${RELEASE_VERSION}$"; then
+          echo "⚠️ Tag ${RELEASE_VERSION} already exists, skipping"
+          exit 0
+        fi
+        
+        # Create annotated tag
+        git tag -a "$RELEASE_VERSION" -m "Monthly Release $RELEASE_VERSION
 
-      - name: Set tags
-        if: steps.when.outputs.RUN == 'true'
-        id: vars
-        run: |
-          MONTH_LOCAL=$(date +'%Y.%m')
-          echo "MONTH_LOCAL=${MONTH_LOCAL}" >> "$GITHUB_OUTPUT"
+        Monthly production release for $(date +"%B %Y")
 
-      - name: Log in to Docker Hub
-        if: steps.when.outputs.RUN == 'true'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+        Build: GitHub Actions #${GITHUB_RUN_NUMBER}
+        Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+        "
+        
+        # Push tag
+        git push origin "$RELEASE_VERSION"
+        
+        echo "✅ Created and pushed tag: $RELEASE_VERSION"
 
-      - name: Set up QEMU
-        if: steps.when.outputs.RUN == 'true'
-        uses: docker/setup-qemu-action@v3
+    - name: "📦 Create GitHub Release"
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Create release notes
+        cat > temp_release_notes.md << EOF
+        # Monthly Release ${RELEASE_VERSION}
+        
+        **Release Date:** $(date +"%Y-%m-%d")
+        **Release Type:** Monthly Release
+        
+        ## Overview
+        
+        Monthly production release for $(date +"%B %Y").
+        
+        ## Docker Images
+        
+        \`\`\`bash
+        docker pull maboni82/dnssec-validator:${RELEASE_VERSION}
+        docker pull maboni82/dnssec-validator:latest
+        \`\`\`
+        
+        ## Technical Details
+        
+        - **Git Tag:** \`${RELEASE_VERSION}\`
+        - **Build:** GitHub Actions #${GITHUB_RUN_NUMBER}
+        - **Platforms:** linux/amd64, linux/arm64
+        
+        EOF
+        
+        # Create GitHub release
+        gh release create "$RELEASE_VERSION" \
+          --title "Monthly Release $RELEASE_VERSION" \
+          --notes-file "temp_release_notes.md" \
+          --target main
+        
+        echo "✅ Created GitHub release: $RELEASE_VERSION"
 
-      - name: Set up Buildx
-        if: steps.when.outputs.RUN == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Create Git tag for official release
-        if: steps.when.outputs.RUN == 'true'
-        run: |
-          TAG_NAME="v${{ steps.vars.outputs.MONTH_LOCAL }}"
-          echo "🏷️  Creating official release tag: $TAG_NAME"
+  summary:
+    name: "📋 Release Summary"
+    needs: create-monthly-release
+    runs-on: ubuntu-latest
+    if: always()
+    
+    steps:
+    - name: "📋 Generate Summary"
+      run: |
+        echo "## 🚀 Monthly Release Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        if [[ "${{ needs.create-monthly-release.result }}" == "success" ]]; then
+          echo "### ✅ Actions Completed" >> $GITHUB_STEP_SUMMARY
+          echo "- 🏷️ Created monthly release tag" >> $GITHUB_STEP_SUMMARY
+          echo "- 📦 Created GitHub release" >> $GITHUB_STEP_SUMMARY
           
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Create and push the tag
-          git tag "$TAG_NAME" -m "Official monthly release $TAG_NAME"
-          git push origin "$TAG_NAME"
-          
-          echo "✅ Official release tag $TAG_NAME created and pushed!"
-          echo "   This will trigger docker-publish.yml to build the official release."
-
-      - name: Create GitHub Release
-        if: steps.when.outputs.RUN == 'true'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.vars.outputs.MONTH_LOCAL }}
-          release_name: Monthly Release v${{ steps.vars.outputs.MONTH_LOCAL }}
-          body: |
-            🚀 **Monthly Release v${{ steps.vars.outputs.MONTH_LOCAL }}**
-            
-            This is an automated monthly release created on the second Sunday of the month.
-            
-            **Docker Images:**
-            - `maboni82/dnssec-validator:v${{ steps.vars.outputs.MONTH_LOCAL }}`
-            - Available for `linux/amd64` and `linux/arm64`
-            
-            **What's Changed:**
-            - See commit history for detailed changes since last monthly release
-            
-            ---
-            *This release was automatically created by the monthly workflow.*
-          draft: false
-          prerelease: false
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 🔄 Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker publish workflow will build and push the Docker image" >> $GITHUB_STEP_SUMMARY
+          echo "- Image will be available as monthly release version" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "### ❌ Release Failed" >> $GITHUB_STEP_SUMMARY
+          echo "Monthly release creation failed. Please check logs for details." >> $GITHUB_STEP_SUMMARY
+        fi
 

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -1,0 +1,222 @@
+name: Auto-Increment Version on PR Merge
+
+# Automatically increments patch version when PR is merged to main branch
+# Handles YY.M.PATCH versioning (e.g., 26.1.1, 26.1.2, etc.)
+# Monthly releases (YY.M.0) are handled by monthly.yml workflow
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      force_version:
+        description: 'Force specific version (e.g., 26.1.15)'
+        required: false
+        type: string
+
+# Allow only one concurrent version increment
+concurrency:
+  group: ${{ github.workflow }}-version-increment
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+  actions: read
+
+jobs:
+  calculate-version:
+    name: "🔢 Calculate Next Version"
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      latest_version: ${{ steps.version.outputs.latest_version }}
+      current_month: ${{ steps.version.outputs.current_month }}
+      should_build: ${{ steps.check.outputs.should_build }}
+      
+    steps:
+    - name: "📦 Checkout Repository"
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # Need full history for tag analysis
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "🔢 Calculate Version"
+      id: version
+      run: |
+        if [[ -n "${{ github.event.inputs.force_version }}" ]]; then
+          # Manual trigger with forced version
+          NEW_VERSION="${{ github.event.inputs.force_version }}"
+          echo "🎯 Using forced version: $NEW_VERSION"
+          
+          # Validate format
+          if ! [[ "$NEW_VERSION" =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]+$ ]]; then
+            echo "❌ Invalid version format: $NEW_VERSION"
+            echo "Expected format: YY.M.PATCH (e.g., 26.1.15)"
+            exit 1
+          fi
+          
+          # Get latest for comparison
+          CURRENT_MONTH=$(date +"%y.%-m")
+          LATEST_VERSION=$(git tag -l "${CURRENT_MONTH}.*" | sort -V | tail -1)
+          if [[ -z "$LATEST_VERSION" ]]; then
+            LATEST_VERSION="${CURRENT_MONTH}.0"
+          fi
+        else
+          # Use increment script for automatic versioning
+          chmod +x scripts/increment-version.sh
+          ./scripts/increment-version.sh
+          
+          # Script outputs to stdout, capture it
+          NEW_VERSION=$(./scripts/increment-version.sh | tail -1)
+          
+          # Get previous version
+          CURRENT_MONTH=$(date +"%y.%-m")
+          LATEST_VERSION=$(git tag -l "${CURRENT_MONTH}.*" | sort -V | tail -1)
+          if [[ -z "$LATEST_VERSION" ]]; then
+            LATEST_VERSION="${CURRENT_MONTH}.0"
+          fi
+        fi
+        
+        echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT  
+        echo "current_month=$(echo "$NEW_VERSION" | cut -d. -f1-2)" >> $GITHUB_OUTPUT
+        
+        echo "📋 Version Calculation:"
+        echo "   Previous: $LATEST_VERSION"
+        echo "   Next: $NEW_VERSION"
+
+    - name: "🔍 Check if Version Already Exists"
+      id: check
+      env:
+        NEW_VERSION: ${{ steps.version.outputs.new_version }}
+      run: |
+        if git tag -l | grep -q "^${NEW_VERSION}$"; then
+          echo "⚠️ Version tag already exists: $NEW_VERSION"
+          if [[ "${{ github.event.inputs.force_version }}" == "$NEW_VERSION" ]]; then
+            echo "🔄 Force mode - will overwrite existing tag"
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          else
+            echo "ℹ️ Skipping build for existing version"
+            echo "should_build=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "✅ New version ready: $NEW_VERSION"
+          echo "should_build=true" >> $GITHUB_OUTPUT
+        fi
+
+  create-tag-and-release:
+    name: "🏷️ Create Tag and Release"
+    runs-on: ubuntu-latest
+    needs: calculate-version
+    if: needs.calculate-version.outputs.should_build == 'true'
+      
+    steps:
+    - name: "📦 Checkout Repository"
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "🏷️ Create Git Tag"
+      env:
+        NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        
+        # Delete existing tag if force mode
+        if git tag -l | grep -q "^${NEW_VERSION}$"; then
+          echo "🔄 Removing existing tag: $NEW_VERSION"
+          git tag -d "$NEW_VERSION" || true
+          git push origin ":refs/tags/$NEW_VERSION" || true
+        fi
+        
+        # Create annotated tag
+        git tag -a "$NEW_VERSION" -m "Patch release $NEW_VERSION
+
+        Automatic patch version increment from main branch merge.
+        
+        Build: GitHub Actions #${GITHUB_RUN_NUMBER}
+        Commit: ${GITHUB_SHA:0:8}
+        Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+        "
+        
+        # Push tag
+        git push origin "$NEW_VERSION"
+        
+        echo "✅ Created and pushed tag: $NEW_VERSION"
+
+    - name: "📦 Create GitHub Release"
+      env:
+        NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Create release notes
+        cat > temp_release_notes.md << EOF
+        # Release ${NEW_VERSION}
+        
+        **Release Date:** $(date +"%Y-%m-%d")
+        **Release Type:** Patch Release
+        **Commit:** ${GITHUB_SHA:0:8}
+        
+        ## Changes
+        
+        Automatic patch release from main branch merge.
+        
+        ## Docker Images
+        
+        \`\`\`bash
+        docker pull maboni82/dnssec-validator:${NEW_VERSION}
+        docker pull maboni82/dnssec-validator:latest
+        \`\`\`
+        
+        ## Technical Details
+        
+        - **Git Tag:** \`${NEW_VERSION}\`
+        - **Build:** GitHub Actions #${GITHUB_RUN_NUMBER}
+        - **Docker Build:** Handled by docker-publish workflow
+        
+        EOF
+        
+        # Create GitHub release
+        gh release create "$NEW_VERSION" \
+          --title "Release $NEW_VERSION" \
+          --notes-file "temp_release_notes.md" \
+          --target main
+        
+        echo "✅ Created GitHub release: $NEW_VERSION"
+
+  summary:
+    name: "📋 Version Summary"
+    runs-on: ubuntu-latest
+    needs: [calculate-version, create-tag-and-release]
+    if: always()
+    
+    steps:
+    - name: "📋 Generate Summary"
+      env:
+        NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+        SHOULD_BUILD: ${{ needs.calculate-version.outputs.should_build }}
+      run: |
+        echo "## 🚀 Version Increment Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Version:** $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
+        echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Tag Created:** $SHOULD_BUILD" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        if [[ "$SHOULD_BUILD" == "true" ]]; then
+          echo "### ✅ Actions Completed" >> $GITHUB_STEP_SUMMARY
+          echo "- 🏷️ Created git tag: \`$NEW_VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 📦 Created GitHub release" >> $GITHUB_STEP_SUMMARY
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 🔄 Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker publish workflow will automatically build and push Docker image" >> $GITHUB_STEP_SUMMARY
+          echo "- Image will be tagged as: \`${NEW_VERSION}\`, \`latest\`" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "### ℹ️ No Action Required" >> $GITHUB_STEP_SUMMARY
+          echo "Version \`$NEW_VERSION\` already exists or no changes detected." >> $GITHUB_STEP_SUMMARY
+        fi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DNSSEC Validator
 
 [![GitHub Release](https://img.shields.io/github/v/release/BondIT-ApS/dnssec-validator?style=for-the-badge&logo=github&label=release)](https://github.com/BondIT-ApS/dnssec-validator/releases/latest)
-[![GitHub Pre-release](https://img.shields.io/github/v/release/BondIT-ApS/dnssec-validator?include_prereleases&style=for-the-badge&logo=github&label=dev)](https://github.com/BondIT-ApS/dnssec-validator/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/maboni82/dnssec-validator?style=for-the-badge&logo=docker)](https://hub.docker.com/r/maboni82/dnssec-validator)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/BondIT-ApS/dnssec-validator/docker-publish.yml?branch=main&style=for-the-badge&logo=github)](https://github.com/BondIT-ApS/dnssec-validator/actions)
 [![Quality Gate](https://img.shields.io/badge/Quality%20Gate-10.0%2F10-brightgreen?style=for-the-badge&logo=python)](https://github.com/BondIT-ApS/dnssec-validator/actions)
@@ -38,11 +37,42 @@ The production deployment includes:
 ## 🐳 Quick Start with Docker
 
 ```bash
-# Run the container
+# Run the container (latest version)
 docker run -p 8080:8080 maboni82/dnssec-validator:latest
+
+# Or run a specific version
+docker run -p 8080:8080 maboni82/dnssec-validator:26.1.1
 
 # Open your browser to http://localhost:8080
 ```
+
+## 🏷️ Versioning
+
+This project uses **semantic versioning** with a `YY.M.PATCH` format:
+
+- **YY.M** = Year and Month (e.g., `26.1` for January 2026)
+- **PATCH** = Incremental patch number (starts at 0 each month)
+
+### Version Examples
+
+- `26.1.0` - First release of January 2026 (monthly release on 1st)
+- `26.1.1`, `26.1.2`, `26.1.3` - Patch releases during January
+- `26.2.0` - First release of February 2026 (monthly release on 1st)
+
+### Docker Tags
+
+- `latest` - Always points to the most recent release
+- `YY.M.PATCH` - Specific version (e.g., `26.1.3`)
+- `YY.M` - Latest patch for that month (e.g., `26.1`)
+
+### Release Schedule
+
+- **Monthly Releases**: Created on the 1st of each month (`YY.M.0`)
+- **Patch Releases**: Automatically created when PRs merge to main
+
+### Release Notes
+
+View all releases and changelogs on the [Releases page](https://github.com/BondIT-ApS/dnssec-validator/releases).
 
 ## 🔧 Manual Installation
 

--- a/releases/history/.gitkeep
+++ b/releases/history/.gitkeep
@@ -1,0 +1,1 @@
+# This directory stores historical release information

--- a/releases/release-candidate.json
+++ b/releases/release-candidate.json
@@ -1,0 +1,6 @@
+{
+  "candidate_version": "",
+  "selected_at": "",
+  "target_release": "26.2.0",
+  "notes": "Release candidate tracking for monthly releases"
+}

--- a/scripts/increment-version.sh
+++ b/scripts/increment-version.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# === scripts/increment-version.sh ===
+# Automatically increment patch version for semantic versioning (YY.M.PATCH)
+# Used by GitHub Actions on PR merge to main branch
+
+set -euo pipefail
+
+# Configuration
+readonly CURRENT_YEAR=$(date +%y)
+readonly CURRENT_MONTH=$(date +%-m)
+
+# Function to get the current month version (e.g., 26.1)
+get_current_month_version() {
+    echo "${CURRENT_YEAR}.${CURRENT_MONTH}"
+}
+
+# Function to get the latest git tag matching the current month
+get_latest_patch_version() {
+    local month_prefix="$1"
+    
+    # Get all tags matching the current month pattern (e.g., 26.1.*)
+    # Sort them by version number and get the latest one
+    local latest_tag
+    latest_tag=$(git tag -l "${month_prefix}.*" | sort -V | tail -n 1)
+    
+    if [[ -z "$latest_tag" ]]; then
+        # No patch versions exist for this month, start with .0
+        echo "${month_prefix}.0"
+    else
+        echo "$latest_tag"
+    fi
+}
+
+# Function to increment the patch version
+increment_patch() {
+    local version="$1"
+    
+    # Extract patch number from version (e.g., "26.1.15" -> "15")
+    local patch_number
+    patch_number=$(echo "$version" | cut -d. -f3)
+    
+    # Increment patch number
+    local new_patch=$((patch_number + 1))
+    
+    # Reconstruct version with incremented patch
+    local month_version
+    month_version=$(echo "$version" | cut -d. -f1-2)
+    
+    echo "${month_version}.${new_patch}"
+}
+
+# Main logic
+main() {
+    echo "🔧 Calculating next patch version..."
+    
+    # Get current month version prefix
+    local month_version
+    month_version=$(get_current_month_version)
+    echo "📅 Current month version prefix: $month_version"
+    
+    # Get latest patch version for current month
+    local current_version
+    current_version=$(get_latest_patch_version "$month_version")
+    echo "🏷️  Latest version: $current_version"
+    
+    # Check if we need to roll to new month
+    local current_month_from_tag
+    current_month_from_tag=$(echo "$current_version" | cut -d. -f2)
+    
+    local new_version
+    if [[ "$current_month_from_tag" != "$CURRENT_MONTH" ]]; then
+        # New month, start from .0
+        new_version="${month_version}.0"
+        echo "🆕 New month detected, starting with: $new_version"
+    else
+        # Same month, increment patch
+        new_version=$(increment_patch "$current_version")
+        echo "⬆️  Incremented to: $new_version"
+    fi
+    
+    # Output the new version for GitHub Actions (if available)
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "NEW_VERSION=$new_version" >> "$GITHUB_OUTPUT"
+        echo "PREVIOUS_VERSION=$current_version" >> "$GITHUB_OUTPUT"
+    fi
+    
+    # Also output to stdout for local usage
+    echo "📦 New version: $new_version"
+    echo "$new_version"
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Overview
This PR implements automatic semantic versioning following the pattern from consultant-portal projects.

## Features
- **YY.M.PATCH format**: , ,  (January), then ,  (February)
- **Automatic patch increment**: Every PR merge to main creates a new patch version
- **Monthly releases**: First of each month creates  release
- **Git tags**: Automatically created for each release
- **GitHub releases**: Generated with release notes
- **Docker tags**: Images tagged with semantic versions

## Implementation Details

### New Files
- `scripts/increment-version.sh` - Bash script to calculate next version
- `.github/workflows/version-increment.yml` - Auto-increment on PR merge
- `releases/release-candidate.json` - Track release candidates
- `releases/history/.gitkeep` - Historical release tracking

## Versioning Flow

### Patch Releases (Automatic)
1. PR merged to main
2. `version-increment.yml` triggers
3. Script calculates next version (e.g., 26.1.0 \u2192 26.1.1)
4. Git tag created and pushed
5. GitHub release created
6. `docker-publish.yml` builds Docker image with version tag

### Monthly Releases (Scheduled)
1. 1st of month at 04:00 CET
2. `monthly.yml` triggers
3. Creates `YY.M.0` tag and release
4. Docker image built with monthly version

## Version Examples

**January 2026:**
- Jan 1: `26.1.0` (monthly release)
- Jan 5: `26.1.1` (PR merge)
- Jan 10: `26.1.2` (PR merge)
- Jan 15: `26.1.3` (PR merge)

**February 2026:**
- Feb 1: `26.2.0` (monthly release)
- Feb 3: `26.2.1` (PR merge)

## Docker Tags

Each release creates multiple Docker tags:
- `latest` - Always points to newest version
- `26.1.3` - Specific patch version
- `26.1` - Latest patch for that month

## Testing

- Script tested locally - correctly increments from 26.1.0 to 26.1.1
- Workflows validated (YAML syntax)
- Documentation updated
- Follows same pattern as consultant-portal-backend