### PR TITLE
Add Codecov upload to main branch workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,10 +10,40 @@ permissions:
   packages: write
 
 jobs:
+  # 📊 Upload Coverage to Codecov (main branch)
+  codecov-main:
+    name: 📊 Upload Coverage Report (Main Branch)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download coverage report from last PR
+        uses: dawidd6/action-download-artifact@v6
+        continue-on-error: true
+        with:
+          workflow: pr-quality-gate.yml
+          name: coverage-report
+          path: .
+          search_artifacts: true
+
+      - name: Upload coverage to Codecov
+        if: hashFiles('coverage.xml') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: unittests
+          name: dnssec-validator-main-coverage
+          fail_ci_if_error: false
+          verbose: true
+
   # 🏢 Production LEGO Assembly Line
   production-build:
     name: 🐳 Build DNSSEC Validator Docker Image
     runs-on: ubuntu-latest
+    needs: codecov-main
 
     steps:
       - name: 📎 Get LEGO Instructions (Checkout)

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -314,6 +314,13 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Save coverage report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          retention-days: 7
+
       - name: Check coverage threshold (50% minimum)
         run: |
           # Extract coverage percentage from XML


### PR DESCRIPTION
## 📊 Codecov Integration for Main Branch

This PR enables coverage tracking on the main branch by uploading coverage reports to Codecov after each merge.

### Changes
- **PR workflow**: Save  as artifact (7-day retention)
- **Production workflow**: Download coverage artifact and upload to Codecov
- **Optimization**: Avoids running tests twice

### Benefits
- 📈 Historical coverage trends on main branch
- 🏷️ Coverage badges reflect main branch status
- ⚡ Faster builds (no duplicate test runs)
- 🎯 Same coverage data from PR uploaded to main

### Implementation
Uses  to fetch the coverage artifact from the last successful PR run, then uploads it to Codecov.

---
🧱 Built with LEGO methodology - every piece matters for DNS security
