### PR TITLE
Fix Codecov integration for continuous main branch tracking

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,23 +18,30 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Download coverage report from last PR
-        uses: dawidd6/action-download-artifact@v6
-        continue-on-error: true
         with:
-          workflow: pr-quality-gate.yml
-          name: coverage-report
-          path: .
-          search_artifacts: true
+          fetch-depth: 0  # Full history for better Codecov analysis
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-cov pytest-mock pytest-flask freezegun requests-mock
+
+      - name: Run tests with coverage
+        run: |
+          python -m pytest tests/ --cov=app --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        if: hashFiles('coverage.xml') != ''
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-          flags: unittests
+          flags: main-branch
           name: dnssec-validator-main-coverage
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -314,13 +314,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Save coverage report as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage.xml
-          retention-days: 7
-
       - name: Check coverage threshold (50% minimum)
         run: |
           # Extract coverage percentage from XML

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/BondIT-ApS/dnssec-validator?style=for-the-badge&logo=github&label=release)](https://github.com/BondIT-ApS/dnssec-validator/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/maboni82/dnssec-validator?style=for-the-badge&logo=docker)](https://hub.docker.com/r/maboni82/dnssec-validator)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/BondIT-ApS/dnssec-validator/docker-publish.yml?branch=main&style=for-the-badge&logo=github)](https://github.com/BondIT-ApS/dnssec-validator/actions)
+[![codecov](https://img.shields.io/codecov/c/github/BondIT-ApS/dnssec-validator?style=for-the-badge&logo=codecov)](https://codecov.io/gh/BondIT-ApS/dnssec-validator)
 [![Quality Gate](https://img.shields.io/badge/Quality%20Gate-10.0%2F10-brightgreen?style=for-the-badge&logo=python)](https://github.com/BondIT-ApS/dnssec-validator/actions)
 [![GitHub Issues](https://img.shields.io/github/issues/BondIT-ApS/dnssec-validator?style=for-the-badge)](https://github.com/BondIT-ApS/dnssec-validator/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/BondIT-ApS/dnssec-validator?style=for-the-badge)](https://github.com/BondIT-ApS/dnssec-validator/stargazers)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,46 @@
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+        flags:
+          - unittests
+          - main-branch
+    patch:
+      default:
+        target: 50%
+        threshold: 5%
+
+flags:
+  unittests:
+    paths:
+      - app/
+    carryforward: false
+  main-branch:
+    paths:
+      - app/
+    carryforward: false
+
+comment:
+  layout: "header, diff, flags, components, footer"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: yes
+
+ignore:
+  - "tests/"
+  - "data/"
+  - ".venv/"
+  - "venv/"
+  - "**/__pycache__"


### PR DESCRIPTION
## Problem
The Codecov integration was experiencing a 'missing head commit' error because we were trying to download coverage artifacts from PR workflows and re-upload them to the main branch. This caused a commit SHA mismatch.

## Solution
This PR fixes the integration by:
- **Generating fresh coverage on main**: Instead of reusing PR artifacts, we now run tests directly on the main branch
- **Removing artifact workflow**: Cleaned up the artifact upload/download approach that was causing the mismatch
- **Added Codecov configuration**: Created `codecov.yml` with proper flags and thresholds
- **Added visibility**: Added Codecov badge to README

## Changes
- `.github/workflows/docker-publish.yml`: Run tests and generate coverage directly on main
- `.github/workflows/pr-quality-gate.yml`: Removed artifact upload (no longer needed)
- `codecov.yml`: Added proper Codecov configuration with flags and thresholds
- `README.md`: Added Codecov badge

## How It Works Now
- **PRs**: Generate coverage with `unittests` flag → upload to Codecov
- **Main branch**: Generate fresh coverage when merged → upload with `main-branch` flag
- Both track continuously without commit mismatches
- Codecov can now properly track coverage trends over time

## Testing
Once merged, the docker-publish workflow will run and upload coverage to Codecov for the main branch. You can then monitor coverage trends at https://codecov.io/gh/BondIT-ApS/dnssec-validator

🧱 **Built with precision - every LEGO piece in placepush*