### PR TITLE
Fix Dependabot schedule to Monday 21:12 CET

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
+      time: "21:12"
       timezone: "Europe/Copenhagen"
     open-pull-requests-limit: 10
     reviewers:
@@ -24,8 +24,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "wednesday"
-      time: "11:00"
+      day: "monday"
+      time: "21:12"
       timezone: "Europe/Copenhagen"
     open-pull-requests-limit: 10
     reviewers:


### PR DESCRIPTION
## Summary

Fix Dependabot schedule configuration to align exactly with the weekly maintenance workflow.

## Issue

The Dependabot configuration was scheduled inconsistently:
- **pip**: Monday 09:00 CET (should be 21:12 CET)
- **docker**: Wednesday 11:00 CET (should be Monday 21:12 CET)
- **dependabot-weekly.yml workflow**: Monday 21:12 CET ✅ (already correct)

## Changes

Updated `.github/dependabot.yml`:
- ✅ **pip**: Now runs Monday 21:12 CET (was Monday 09:00 CET)
- ✅ **docker**: Now runs Monday 21:12 CET (was Wednesday 11:00 CET)

Both Dependabot and the weekly maintenance workflow now run at the **exact same time: Monday 21:12 CET**.

## Testing

Configuration follows GitHub Dependabot v2 schema and will be validated automatically.