### PR TITLE
Fix versioning to reset patch number at beginning of each month

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,9 +66,22 @@ jobs:
           # Generate YY.M format from current date
           YEAR_MONTH=$(date +'%y.%-m')
 
-          # Use GitHub run number as patch version for simplicity
-          # This ensures each build gets an incrementing patch number
-          PATCH_VERSION="${{ github.run_number }}"
+          # Find the highest patch version for the current month
+          # Get all tags matching the current month pattern
+          EXISTING_TAGS=$(git tag -l "${YEAR_MONTH}.*" | sort -V)
+
+          if [ -z "$EXISTING_TAGS" ]; then
+            # No tags for this month yet, start at 1
+            PATCH_VERSION=1
+            echo "📦 No existing tags for ${YEAR_MONTH}, starting at patch version 1"
+          else
+            # Extract the highest patch number and increment
+            HIGHEST_TAG=$(echo "$EXISTING_TAGS" | tail -1)
+            HIGHEST_PATCH=$(echo "$HIGHEST_TAG" | cut -d'.' -f3)
+            PATCH_VERSION=$((HIGHEST_PATCH + 1))
+            echo "📦 Found existing tags for ${YEAR_MONTH}, highest: ${HIGHEST_TAG}"
+            echo "📦 Incrementing to patch version: ${PATCH_VERSION}"
+          fi
 
           # Create semantic version: YY.M.PATCH
           VERSION="${YEAR_MONTH}.${PATCH_VERSION}"
@@ -81,7 +94,7 @@ jobs:
 
           echo "🏷️ Building semantic version: ${VERSION}"
           echo "📅 Year/Month tag: ${YEAR_MONTH_TAG}"
-          echo "🔢 Run number: ${PATCH_VERSION}"
+          echo "🔢 Patch version: ${PATCH_VERSION}"
 
       - name: 🌍 Set up Multi-Platform Builder (QEMU)
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Summary

Fix the semantic versioning system to reset patch numbers to 1 at the beginning of each month, as intended by the YY.M.PATCH format.

## Problem

The current workflow uses `github.run_number` for the patch version, which is a global counter that **never resets**.

**Current behavior (incorrect):**
- January: `26.1.9`, `26.1.99`, `26.1.100` ✅
- February: Would continue to `26.2.101`, `26.2.102`, `26.2.103` ❌ (wrong!)

**Expected behavior:**
- January: `26.1.1`, `26.1.2`, ..., `26.1.100` ✅
- February: `26.2.1`, `26.2.2`, `26.2.3` ✅ (resets to 1)

## Solution

Changed the version generation logic to:

1. Get current month in `YY.M` format (e.g., `26.1`, `26.2`)
2. Find all existing git tags matching that pattern
3. Extract the highest patch number
4. Increment by 1
5. If no tags exist for the current month, start at 1

## Implementation

```bash
# Find all tags for current month
EXISTING_TAGS=$(git tag -l "${YEAR_MONTH}.*" | sort -V)

if [ -z "$EXISTING_TAGS" ]; then
  # No tags for this month yet, start at 1
  PATCH_VERSION=1
else
  # Extract highest patch and increment
  HIGHEST_TAG=$(echo "$EXISTING_TAGS" | tail -1)
  HIGHEST_PATCH=$(echo "$HIGHEST_TAG" | cut -d'.' -f3)
  PATCH_VERSION=$((HIGHEST_PATCH + 1))
fi
```

## Testing

Tested with current repository tags:
- ✅ **Current month (26.1):** Finds highest tag `26.1.100`, next version will be `26.1.101`
- ✅ **Next month (26.2):** No tags found, first version will be `26.2.1`

## Impact

- Next build in January: `26.1.101`
- First build in February: `26.2.1` (resets as intended)
- Properly follows semantic versioning: `YY.M.PATCH`