### PR TITLE
chore(deps): consolidate all pending dependabot updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 Flask==3.1.3
 dnspython==2.8.0
-cryptography>=46.0.3
-gunicorn==25.1.0
+cryptography>=48.0.0
+gunicorn==26.0.0
 flask-cors>=6.0.2
 flask-limiter==4.1.1
-requests==2.32.5
+requests==2.34.0
 python-dateutil==2.9.0.post0
 flask-restx>=1.3.2
 flask-talisman>=1.1.0
-psutil>=7.2.1
+psutil>=7.2.2
 influxdb-client>=1.50.0
-click>=8.3.1
+click>=8.3.3
 
 # Testing dependencies
-pytest>=9.0.2
-pytest-cov>=7.0.0
+pytest>=9.0.3
+pytest-cov>=7.1.0
 pytest-mock>=3.15.1
 pytest-flask>=1.3.0
 requests-mock>=1.12.1

--- a/tests/integration/test_bulk_validation_endpoint.py
+++ b/tests/integration/test_bulk_validation_endpoint.py
@@ -125,9 +125,7 @@ class TestBulkValidationEndpoint:
         """Test bulk validation with invalid timeout value"""
         response = client.post(
             "/api/validate/bulk",
-            data=json.dumps(
-                {"domains": ["bondit.dk"], "options": {"timeout": 200}}
-            ),
+            data=json.dumps({"domains": ["bondit.dk"], "options": {"timeout": 200}}),
             content_type="application/json",
         )
 
@@ -155,7 +153,9 @@ class TestBulkValidationEndpoint:
 
         response = client.post(
             "/api/validate/bulk",
-            data=json.dumps({"domains": ["https://bondit.dk", "http://bondit.dk/path"]}),
+            data=json.dumps(
+                {"domains": ["https://bondit.dk", "http://bondit.dk/path"]}
+            ),
             content_type="application/json",
         )
 


### PR DESCRIPTION
## Summary
Consolidates all 8 pending dependabot dependency updates into a single PR as tracked in #147.

### Updated Dependencies
- **cryptography**: `>=46.0.3` → `>=48.0.0` (post-quantum algorithm support via OpenSSL 3.5)
- **gunicorn**: `25.1.0` → `26.0.0` (security hardening, eventlet removal)
- **requests**: `2.32.5` → `2.34.0` (inline types, security fixes)
- **click**: `>=8.3.1` → `>=8.3.3` (bug fixes, security improvements)
- **psutil**: `>=7.2.1` → `>=7.2.2` (macOS/Linux improvements)
- **pytest**: `>=9.0.2` → `>=9.0.3` (CVE-2025-71176 fix)
- **pytest-cov**: `>=7.0.0` → `>=7.1.0`

### Validation
- All 160 tests pass
- Pylint score: 9.99/10
- Black formatting applied
- Docker build and startup verified locally

### Closes
Closes #132, #134, #135, #141, #142, #143, #144, #146, #148, #149