### PR TITLE
Add domain-specific validation history (closes #72)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,6 +17,12 @@ SHOW_VALIDATION_TLSA_DANE=false
 # Show/hide BondIT attribution footer in web UI (true/false)
 SHOW_BONDIT_ATTRIBUTION=true
 
+# Enable domain-specific validation history (true/false)
+# When true:
+#   - /api/analytics/domain/<domain> endpoint is exposed
+#   - Validation counts in Top Validated Domains become clickable filters on /stats
+SHOW_DOMAIN_CHECK_HISTORY=false
+
 # ========================================
 # Google Analytics Configuration
 # ========================================

--- a/app/app.py
+++ b/app/app.py
@@ -178,6 +178,12 @@ def show_attribution():
     return attribution in ["true", "1", "yes"]  # Support true, 1, yes for flexibility
 
 
+def show_domain_check_history():
+    """Check if domain-specific validation history is enabled"""
+    flag = os.getenv("SHOW_DOMAIN_CHECK_HISTORY", "false").lower()
+    return flag in ["true", "1", "yes"]
+
+
 # Google Analytics configuration
 def get_analytics_config():
     """Get Google Analytics configuration with validation"""
@@ -204,6 +210,12 @@ def get_analytics_config():
 def inject_attribution():
     """Make attribution setting available to all templates"""
     return {"show_attribution": show_attribution()}
+
+
+@app.context_processor
+def inject_domain_check_history():
+    """Make domain history flag available to all templates"""
+    return {"show_domain_check_history": show_domain_check_history()}
 
 
 @app.context_processor
@@ -1226,6 +1238,89 @@ class AnalyticsSources(Resource):
         except Exception as e:
             logger.error(f"Analytics sources error: {str(e)}", exc_info=True)
             return {"error": "Failed to fetch source breakdown"}, 500
+
+
+@ns_analytics.route("/domain/<path:domain>")
+@ns_analytics.param("domain", "The domain to fetch validation history for")
+class AnalyticsDomain(Resource):
+    @ns_analytics.doc("get_domain_analytics")
+    @ns_analytics.param(
+        "period", "Time period: 1h, 24h, 7d, 30d", _in="query", default="24h"
+    )
+    @ns_analytics.response(200, "Success - Domain analytics data")
+    @ns_analytics.response(400, "Bad Request - Invalid domain or period")
+    @ns_analytics.response(404, "Not Found - Feature disabled")
+    @limiter.limit(
+        f"{rate_limits['api_minute']} per minute; {rate_limits['api_hour']} per hour"
+    )
+    def get(self, domain):
+        """
+        Get domain-specific validation analytics
+
+        Returns request counts, validation ratio, source breakdown, and
+        a request timeline for a single domain over the requested period.
+
+        Gated by the SHOW_DOMAIN_CHECK_HISTORY environment variable.
+        """
+        if not show_domain_check_history():
+            return {"error": "Domain history feature is disabled"}, 404
+
+        try:
+            from domain_utils import extract_domain_from_input, is_valid_domain_format
+
+            extracted = extract_domain_from_input(domain)
+            if not extracted or not is_valid_domain_format(extracted):
+                return {"error": f"Invalid domain: {domain}"}, 400
+            domain = extracted
+
+            period = request.args.get("period", "24h")
+            if period == "1h":
+                hours, days, window = 1, None, "5m"
+            elif period == "24h":
+                hours, days, window = 24, None, "15m"
+            elif period == "7d":
+                hours, days, window = 168, None, "1d"
+            elif period == "30d":
+                hours, days, window = 720, None, "1d"
+            else:
+                return {"error": "Invalid period. Use: 1h, 24h, 7d, 30d"}, 400
+
+            total = RequestLog.get_domain_requests_count(
+                domain=domain, hours=hours, days=days
+            )
+            validation_ratio = RequestLog.get_domain_validation_ratio(
+                domain=domain, hours=hours, days=days
+            )
+            source_data = RequestLog.get_domain_source_breakdown(
+                domain=domain, hours=hours, days=days
+            )
+            hourly_data = RequestLog.get_domain_hourly_requests(
+                domain=domain, hours=hours, window_every=window
+            )
+
+            sources = {"external": 0, "webapp": 0}
+            for client, count in source_data:
+                key = client or "external"
+                if key not in sources:
+                    sources[key] = 0
+                sources[key] += count
+
+            timeline = [
+                {"timestamp": ts, "requests": count} for ts, count in hourly_data
+            ]
+
+            return {
+                "domain": domain,
+                "period": period,
+                "total_requests": total,
+                "validation_ratio": validation_ratio,
+                "sources": sources,
+                "timeline": timeline,
+            }, 200
+
+        except Exception as e:
+            logger.error(f"Domain analytics error: {str(e)}", exc_info=True)
+            return {"error": "Failed to fetch domain analytics"}, 500
 
 
 # Custom error handlers for rate limiting

--- a/app/models.py
+++ b/app/models.py
@@ -146,6 +146,7 @@ class InfluxDBLogger:
         days: int = None,
         source: str = None,
         include_internal: bool = True,
+        domain: str = None,
     ) -> int:
         """Get request count for specified time period"""
         try:
@@ -173,6 +174,10 @@ class InfluxDBLogger:
             # Add source filter if specified
             if source:
                 flux_query += f'|> filter(fn: (r) => r.source == "{source}")'
+
+            # Add domain filter if specified
+            if domain:
+                flux_query += f'|> filter(fn: (r) => r.domain == "{domain}")'
 
             # Collapse all series and sum
             flux_query += "|> group() |> sum()"
@@ -239,6 +244,7 @@ class InfluxDBLogger:
         hours: int = None,
         include_internal: bool = True,
         source: str = "api",
+        domain: str = None,
     ) -> Dict[str, Any]:
         """Get ratio of valid vs invalid vs error validations.
         Percentages are computed excluding 'error' from the denominator (valid+invalid).
@@ -261,6 +267,10 @@ class InfluxDBLogger:
             # Only API by default
             if source:
                 flux_query += f'|> filter(fn: (r) => r.source == "{source}")'
+
+            # Add domain filter if specified
+            if domain:
+                flux_query += f'|> filter(fn: (r) => r.domain == "{domain}")'
 
             flux_query += '|> group(columns: ["dnssec_status"]) |> sum()'
 
@@ -301,6 +311,7 @@ class InfluxDBLogger:
         include_internal: bool = True,
         window_every: str = "1h",
         source: str = "api",
+        domain: str = None,
     ) -> List[tuple]:
         """Get request counts aggregated by a dynamic window. Returns list of (ISO timestamp, count)."""
         try:
@@ -319,6 +330,10 @@ class InfluxDBLogger:
             # Only API by default
             if source:
                 flux_query += f'|> filter(fn: (r) => r.source == "{source}")'
+
+            # Add domain filter if specified
+            if domain:
+                flux_query += f'|> filter(fn: (r) => r.domain == "{domain}")'
 
             flux_query += f"""
                 |> drop(columns: ["domain", "dnssec_status", "ip_address", "_measurement", "_field"])
@@ -350,7 +365,12 @@ class InfluxDBLogger:
             print(f"Error getting hourly requests: {e}")
             return []
 
-    def get_source_breakdown(self, days: int = None, hours: int = None) -> List[tuple]:
+    def get_source_breakdown(
+        self,
+        days: int = None,
+        hours: int = None,
+        domain: str = None,
+    ) -> List[tuple]:
         """Get breakdown of API usage 'external' vs 'webapp' via client tag for API-only requests"""
         try:
             time_range = f"-{hours}h" if hours else (f"-{days}d" if days else "-30d")
@@ -361,6 +381,13 @@ class InfluxDBLogger:
                 |> filter(fn: (r) => r._measurement == "request")
                 |> filter(fn: (r) => r._field == "count")
                 |> filter(fn: (r) => r.source == "api")
+            """
+
+            # Add domain filter if specified
+            if domain:
+                flux_query += f'|> filter(fn: (r) => r.domain == "{domain}")'
+
+            flux_query += """
                 |> group(columns: ["client"])
                 |> sum()
             """
@@ -598,3 +625,46 @@ class RequestLog:
         return influx_logger.get_hourly_requests(
             hours, include_internal=False, window_every=window_every, source="api"
         )
+
+    # Domain-scoped methods for per-domain history dashboard
+    @classmethod
+    def get_domain_requests_count(
+        cls, domain: str, hours: int = None, days: int = None
+    ) -> int:
+        return influx_logger.get_requests_count(
+            hours=hours,
+            days=days,
+            source="api",
+            include_internal=False,
+            domain=domain,
+        )
+
+    @classmethod
+    def get_domain_validation_ratio(
+        cls, domain: str, hours: int = None, days: int = None
+    ) -> Dict[str, Any]:
+        return influx_logger.get_validation_ratio(
+            days=days,
+            hours=hours,
+            include_internal=False,
+            source="api",
+            domain=domain,
+        )
+
+    @classmethod
+    def get_domain_hourly_requests(
+        cls, domain: str, hours: int = 24, window_every: str = "1h"
+    ) -> List[tuple]:
+        return influx_logger.get_hourly_requests(
+            hours,
+            include_internal=False,
+            window_every=window_every,
+            source="api",
+            domain=domain,
+        )
+
+    @classmethod
+    def get_domain_source_breakdown(
+        cls, domain: str, hours: int = None, days: int = None
+    ) -> List[tuple]:
+        return influx_logger.get_source_breakdown(days=days, hours=hours, domain=domain)

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -193,6 +193,52 @@
             color: #3498db;
             font-weight: bold;
         }
+
+        .domain-count-link {
+            color: #3498db;
+            text-decoration: none;
+            font-weight: bold;
+            cursor: pointer;
+            transition: color 0.3s, text-decoration 0.3s;
+        }
+
+        .domain-count-link:hover {
+            color: #2980b9;
+            text-decoration: underline;
+        }
+
+        .filter-banner {
+            background: #ecf6fd;
+            border: 1px solid #3498db;
+            color: #2c3e50;
+            padding: 12px 18px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .filter-banner strong {
+            color: #2980b9;
+        }
+
+        .clear-filter-btn {
+            padding: 6px 14px;
+            background: #e74c3c;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            text-decoration: none;
+            font-size: 0.9em;
+        }
+
+        .clear-filter-btn:hover {
+            background: #c0392b;
+        }
         
         .loading {
             text-align: center;
@@ -256,6 +302,11 @@
             <button class="time-btn" data-period="30d">Last 30 Days</button>
             <button class="refresh-btn" id="refresh-btn">🔄 Refresh</button>
         </div>
+
+        <div id="filter-banner" class="filter-banner" style="display: none;">
+            <span>Filtering by domain: <strong id="filter-domain-name"></strong></span>
+            <a href="/stats" class="clear-filter-btn">✕ Clear filter</a>
+        </div>
         
         <div class="stats-grid">
             <div class="stat-card">
@@ -299,7 +350,7 @@
             </div>
         </div>
         
-        <div class="top-domains">
+        <div class="top-domains" id="top-domains-section">
             <div class="chart-title">Top Validated Domains</div>
             <ul class="domains-list" id="top-domains-list">
                 <li class="loading">Loading domains...</li>
@@ -308,6 +359,8 @@
     </div>
 
     <script>
+        const SHOW_DOMAIN_CHECK_HISTORY = {{ 'true' if show_domain_check_history else 'false' }};
+        const FILTER_DOMAIN = new URLSearchParams(window.location.search).get('domain');
         let currentPeriod = '1h';
         let charts = {};
         
@@ -416,75 +469,13 @@
             try {
                 // Show loading state
                 document.querySelectorAll('.stat-number').forEach(el => el.textContent = '-');
-                
-                // Fetch overview data
-                const overviewResponse = await fetch(`/api/analytics/overview?period=${currentPeriod}`);
-                const overviewData = await overviewResponse.json();
-                
-                if (overviewResponse.ok) {
-                    console.log('Overview data:', overviewData);
-                    
-                    // Update stats cards
-                    document.getElementById('total-requests').textContent = (overviewData.total_requests || 0).toLocaleString();
-                    document.getElementById('api-requests').textContent = (overviewData.api_requests || 0).toLocaleString();
-                    document.getElementById('web-requests').textContent = (overviewData.web_requests || 0).toLocaleString();
-                    
-                    const successRate = overviewData.validation_ratio && overviewData.validation_ratio.valid ? 
-                        overviewData.validation_ratio.valid.percentage : 0;
-                    document.getElementById('success-rate').textContent = successRate + '%';
-                    
-                    // Update validation chart
-                    if (overviewData.validation_ratio) {
-                        const validationData = overviewData.validation_ratio;
-                        charts.validation.data.datasets[0].data = [
-                            validationData.valid ? validationData.valid.count : 0,
-                            validationData.invalid ? validationData.invalid.count : 0,
-                            validationData.error ? validationData.error.count : 0
-                        ];
-                        charts.validation.update();
-                    }
-                    
-                    // Update top domains
-                    const domainsList = document.getElementById('top-domains-list');
-                    if (overviewData.top_domains && overviewData.top_domains.length > 0) {
-                        domainsList.innerHTML = overviewData.top_domains.map(([domain, count]) => `
-                            <li>
-                                <a href="/${domain}" class="domain-link" target="_blank" rel="noopener noreferrer" title="Validate ${domain} in new tab">${domain}</a>
-                                <span class="domain-count">${count.toLocaleString()}</span>
-                            </li>
-                        `).join('');
-                    } else {
-                        domainsList.innerHTML = '<li style="text-align: center; color: #7f8c8d;">No data available</li>';
-                    }
+
+                if (SHOW_DOMAIN_CHECK_HISTORY && FILTER_DOMAIN) {
+                    await updateDomainAnalytics(FILTER_DOMAIN);
                 } else {
-                    console.error('Failed to fetch overview data:', overviewResponse.status, overviewData);
+                    await updateOverviewAnalytics();
                 }
-                
-                // Fetch time series data
-                const timeseriesResponse = await fetch(`/api/analytics/timeseries?period=${currentPeriod}`);
-                const timeseriesData = await timeseriesResponse.json();
-                
-                if (timeseriesResponse.ok && timeseriesData.data) {
-                    const labels = timeseriesData.data.map(item => formatTimestamp(item.timestamp));
-                    const data = timeseriesData.data.map(item => item.requests);
-                    
-                    charts.timeseries.data.labels = labels;
-                    charts.timeseries.data.datasets[0].data = data;
-                    charts.timeseries.update();
-                }
-                
-                // Fetch sources data for selected period
-                const sourcesResponse = await fetch(`/api/analytics/sources?period=${currentPeriod}`);
-                const sourcesData = await sourcesResponse.json();
-                
-                if (sourcesResponse.ok) {
-                    charts.sources.data.datasets[0].data = [
-                        sourcesData.external || 0,
-                        sourcesData.webapp || 0
-                    ];
-                    charts.sources.update();
-                }
-                
+
             } catch (error) {
                 console.error('Error updating analytics:', error);
                 const errorDiv = document.createElement('div');
@@ -494,10 +485,138 @@
                 setTimeout(() => errorDiv.remove(), 5000);
             }
         }
+
+        async function updateOverviewAnalytics() {
+            // Fetch overview data
+            const overviewResponse = await fetch(`/api/analytics/overview?period=${currentPeriod}`);
+            const overviewData = await overviewResponse.json();
+
+            if (overviewResponse.ok) {
+                document.getElementById('total-requests').textContent = (overviewData.total_requests || 0).toLocaleString();
+                document.getElementById('api-requests').textContent = (overviewData.api_requests || 0).toLocaleString();
+                document.getElementById('web-requests').textContent = (overviewData.web_requests || 0).toLocaleString();
+
+                const successRate = overviewData.validation_ratio && overviewData.validation_ratio.valid ?
+                    overviewData.validation_ratio.valid.percentage : 0;
+                document.getElementById('success-rate').textContent = successRate + '%';
+
+                if (overviewData.validation_ratio) {
+                    const validationData = overviewData.validation_ratio;
+                    charts.validation.data.datasets[0].data = [
+                        validationData.valid ? validationData.valid.count : 0,
+                        validationData.invalid ? validationData.invalid.count : 0,
+                        validationData.error ? validationData.error.count : 0
+                    ];
+                    charts.validation.update();
+                }
+
+                renderTopDomains(overviewData.top_domains);
+            } else {
+                console.error('Failed to fetch overview data:', overviewResponse.status, overviewData);
+            }
+
+            // Fetch time series data
+            const timeseriesResponse = await fetch(`/api/analytics/timeseries?period=${currentPeriod}`);
+            const timeseriesData = await timeseriesResponse.json();
+
+            if (timeseriesResponse.ok && timeseriesData.data) {
+                const labels = timeseriesData.data.map(item => formatTimestamp(item.timestamp));
+                const data = timeseriesData.data.map(item => item.requests);
+                charts.timeseries.data.labels = labels;
+                charts.timeseries.data.datasets[0].data = data;
+                charts.timeseries.update();
+            }
+
+            // Fetch sources data for selected period
+            const sourcesResponse = await fetch(`/api/analytics/sources?period=${currentPeriod}`);
+            const sourcesData = await sourcesResponse.json();
+
+            if (sourcesResponse.ok) {
+                charts.sources.data.datasets[0].data = [
+                    sourcesData.external || 0,
+                    sourcesData.webapp || 0
+                ];
+                charts.sources.update();
+            }
+        }
+
+        async function updateDomainAnalytics(domain) {
+            const response = await fetch(`/api/analytics/domain/${encodeURIComponent(domain)}?period=${currentPeriod}`);
+            const data = await response.json();
+
+            if (!response.ok) {
+                console.error('Failed to fetch domain analytics:', response.status, data);
+                return;
+            }
+
+            const total = data.total_requests || 0;
+            document.getElementById('total-requests').textContent = total.toLocaleString();
+            document.getElementById('api-requests').textContent = (data.sources && data.sources.external || 0).toLocaleString();
+            document.getElementById('web-requests').textContent = (data.sources && data.sources.webapp || 0).toLocaleString();
+
+            const successRate = data.validation_ratio && data.validation_ratio.valid ?
+                data.validation_ratio.valid.percentage : 0;
+            document.getElementById('success-rate').textContent = successRate + '%';
+
+            if (data.validation_ratio) {
+                charts.validation.data.datasets[0].data = [
+                    data.validation_ratio.valid ? data.validation_ratio.valid.count : 0,
+                    data.validation_ratio.invalid ? data.validation_ratio.invalid.count : 0,
+                    data.validation_ratio.error ? data.validation_ratio.error.count : 0
+                ];
+                charts.validation.update();
+            }
+
+            if (data.timeline) {
+                charts.timeseries.data.labels = data.timeline.map(item => formatTimestamp(item.timestamp));
+                charts.timeseries.data.datasets[0].data = data.timeline.map(item => item.requests);
+                charts.timeseries.update();
+            }
+
+            if (data.sources) {
+                charts.sources.data.datasets[0].data = [
+                    data.sources.external || 0,
+                    data.sources.webapp || 0
+                ];
+                charts.sources.update();
+            }
+        }
+
+        function renderTopDomains(topDomains) {
+            const domainsList = document.getElementById('top-domains-list');
+            if (!topDomains || topDomains.length === 0) {
+                domainsList.innerHTML = '<li style="text-align: center; color: #7f8c8d;">No data available</li>';
+                return;
+            }
+            domainsList.innerHTML = topDomains.map(([domain, count]) => {
+                const safeDomain = String(domain).replace(/[<>"']/g, '');
+                const countCell = SHOW_DOMAIN_CHECK_HISTORY
+                    ? `<a href="/stats?domain=${encodeURIComponent(safeDomain)}" class="domain-count-link" title="View history for ${safeDomain}">${count.toLocaleString()}</a>`
+                    : `<span class="domain-count">${count.toLocaleString()}</span>`;
+                return `
+                    <li>
+                        <a href="/${safeDomain}" class="domain-link" target="_blank" rel="noopener noreferrer" title="Validate ${safeDomain} in new tab">${safeDomain}</a>
+                        ${countCell}
+                    </li>
+                `;
+            }).join('');
+        }
         
+        function applyDomainFilterUI() {
+            if (SHOW_DOMAIN_CHECK_HISTORY && FILTER_DOMAIN) {
+                const banner = document.getElementById('filter-banner');
+                document.getElementById('filter-domain-name').textContent = FILTER_DOMAIN;
+                banner.style.display = 'flex';
+                document.getElementById('top-domains-section').style.display = 'none';
+                document.querySelector('.dashboard-title').textContent =
+                    `📊 Analytics: ${FILTER_DOMAIN}`;
+            }
+        }
+
         // Event listeners
         document.addEventListener('DOMContentLoaded', function() {
             initCharts();
+            applyDomainFilterUI();
             updateAnalytics();
             
             // Time period selection

--- a/tests/unit/test_domain_history.py
+++ b/tests/unit/test_domain_history.py
@@ -1,0 +1,223 @@
+"""
+Unit tests for the SHOW_DOMAIN_CHECK_HISTORY feature: feature flag,
+per-domain InfluxDB query helpers, and the /api/analytics/domain/<domain> endpoint.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../app"))
+
+
+class TestDomainHistoryFeatureFlag(unittest.TestCase):
+    """Test SHOW_DOMAIN_CHECK_HISTORY environment flag parsing."""
+
+    def setUp(self):
+        os.environ.pop("SHOW_DOMAIN_CHECK_HISTORY", None)
+
+    def tearDown(self):
+        os.environ.pop("SHOW_DOMAIN_CHECK_HISTORY", None)
+
+    def test_disabled_by_default(self):
+        import importlib
+        import app as app_module
+
+        importlib.reload(app_module)
+        self.assertFalse(app_module.show_domain_check_history())
+
+    def test_enabled_with_true_values(self):
+        import importlib
+        import app as app_module
+
+        for value in ["true", "True", "TRUE", "1", "yes", "Yes", "YES"]:
+            os.environ["SHOW_DOMAIN_CHECK_HISTORY"] = value
+            importlib.reload(app_module)
+            self.assertTrue(
+                app_module.show_domain_check_history(),
+                f"Expected True for SHOW_DOMAIN_CHECK_HISTORY={value}",
+            )
+
+    def test_disabled_with_false_values(self):
+        import importlib
+        import app as app_module
+
+        for value in ["false", "False", "0", "no", ""]:
+            os.environ["SHOW_DOMAIN_CHECK_HISTORY"] = value
+            importlib.reload(app_module)
+            self.assertFalse(
+                app_module.show_domain_check_history(),
+                f"Expected False for SHOW_DOMAIN_CHECK_HISTORY={value}",
+            )
+
+    def test_context_processor_injects_flag(self):
+        import importlib
+        import app as app_module
+
+        os.environ["SHOW_DOMAIN_CHECK_HISTORY"] = "true"
+        importlib.reload(app_module)
+        result = app_module.inject_domain_check_history()
+        self.assertIn("show_domain_check_history", result)
+        self.assertTrue(result["show_domain_check_history"])
+
+
+class TestInfluxDomainQueries(unittest.TestCase):
+    """Test that domain filter is applied to InfluxDB queries."""
+
+    def _make_logger_with_capture(self):
+        from models import InfluxDBLogger
+
+        logger = InfluxDBLogger()
+        captured = {}
+
+        def fake_execute(flux_query):
+            captured["query"] = flux_query
+            return []
+
+        logger._execute_query = fake_execute  # type: ignore[assignment]
+        return logger, captured
+
+    def test_get_requests_count_includes_domain_filter(self):
+        logger, captured = self._make_logger_with_capture()
+        logger.get_requests_count(hours=24, domain="example.com")
+        self.assertIn('r.domain == "example.com"', captured["query"])
+
+    def test_get_validation_ratio_includes_domain_filter(self):
+        logger, captured = self._make_logger_with_capture()
+        logger.get_validation_ratio(hours=24, domain="example.com")
+        self.assertIn('r.domain == "example.com"', captured["query"])
+
+    def test_get_hourly_requests_includes_domain_filter(self):
+        logger, captured = self._make_logger_with_capture()
+        logger.get_hourly_requests(hours=24, domain="example.com")
+        self.assertIn('r.domain == "example.com"', captured["query"])
+
+    def test_get_source_breakdown_includes_domain_filter(self):
+        logger, captured = self._make_logger_with_capture()
+        logger.get_source_breakdown(days=7, domain="example.com")
+        self.assertIn('r.domain == "example.com"', captured["query"])
+
+    def test_queries_without_domain_have_no_domain_filter(self):
+        logger, captured = self._make_logger_with_capture()
+        logger.get_requests_count(hours=24)
+        self.assertNotIn("r.domain == ", captured["query"])
+
+
+class TestDomainAnalyticsEndpoint(unittest.TestCase):
+    """Test /api/analytics/domain/<domain> endpoint behavior."""
+
+    def setUp(self):
+        os.environ.pop("SHOW_DOMAIN_CHECK_HISTORY", None)
+        # Disable rate limiting so test_client requests aren't throttled
+        os.environ["FLASK_ENV"] = "testing"
+
+    def tearDown(self):
+        os.environ.pop("SHOW_DOMAIN_CHECK_HISTORY", None)
+
+    def _reload_app(self):
+        import importlib
+        import app as app_module
+
+        importlib.reload(app_module)
+        # Disable rate limiter for tests
+        app_module.limiter.enabled = False
+        return app_module
+
+    def test_endpoint_returns_404_when_feature_disabled(self):
+        app_module = self._reload_app()
+        with app_module.app.test_client() as client:
+            response = client.get("/api/analytics/domain/example.com")
+            self.assertEqual(response.status_code, 404)
+            self.assertIn("disabled", response.get_json()["error"].lower())
+
+    def test_endpoint_rejects_invalid_domain(self):
+        os.environ["SHOW_DOMAIN_CHECK_HISTORY"] = "true"
+        app_module = self._reload_app()
+        with app_module.app.test_client() as client:
+            response = client.get("/api/analytics/domain/not_a_valid_domain")
+            self.assertEqual(response.status_code, 400)
+
+    def test_endpoint_rejects_invalid_period(self):
+        os.environ["SHOW_DOMAIN_CHECK_HISTORY"] = "true"
+        app_module = self._reload_app()
+        with patch.object(
+            app_module.RequestLog, "get_domain_requests_count", return_value=0
+        ):
+            with app_module.app.test_client() as client:
+                response = client.get("/api/analytics/domain/example.com?period=99h")
+                self.assertEqual(response.status_code, 400)
+
+    def test_endpoint_returns_aggregated_payload(self):
+        os.environ["SHOW_DOMAIN_CHECK_HISTORY"] = "true"
+        app_module = self._reload_app()
+
+        with patch.object(
+            app_module.RequestLog, "get_domain_requests_count", return_value=42
+        ), patch.object(
+            app_module.RequestLog,
+            "get_domain_validation_ratio",
+            return_value={
+                "total": 42,
+                "valid": {"count": 40, "percentage": 95.2},
+                "invalid": {"count": 2, "percentage": 4.8},
+                "error": {"count": 0, "percentage": 0},
+            },
+        ), patch.object(
+            app_module.RequestLog,
+            "get_domain_source_breakdown",
+            return_value=[("external", 30), ("webapp", 12)],
+        ), patch.object(
+            app_module.RequestLog,
+            "get_domain_hourly_requests",
+            return_value=[("2026-05-16T10:00:00", 5), ("2026-05-16T11:00:00", 7)],
+        ):
+            with app_module.app.test_client() as client:
+                response = client.get("/api/analytics/domain/example.com?period=24h")
+                self.assertEqual(response.status_code, 200)
+                data = response.get_json()
+                self.assertEqual(data["domain"], "example.com")
+                self.assertEqual(data["period"], "24h")
+                self.assertEqual(data["total_requests"], 42)
+                self.assertEqual(data["sources"], {"external": 30, "webapp": 12})
+                self.assertEqual(len(data["timeline"]), 2)
+                self.assertEqual(data["timeline"][0]["requests"], 5)
+
+
+class TestStatsTemplateRendering(unittest.TestCase):
+    """Test that the stats template renders the feature flag and clickable counts correctly."""
+
+    def setUp(self):
+        os.environ.pop("SHOW_DOMAIN_CHECK_HISTORY", None)
+
+    def tearDown(self):
+        os.environ.pop("SHOW_DOMAIN_CHECK_HISTORY", None)
+
+    def _reload_app(self):
+        import importlib
+        import app as app_module
+
+        importlib.reload(app_module)
+        app_module.limiter.enabled = False
+        return app_module
+
+    def test_stats_page_renders_flag_false_by_default(self):
+        app_module = self._reload_app()
+        with app_module.app.test_client() as client:
+            response = client.get("/stats")
+            self.assertEqual(response.status_code, 200)
+            html = response.data.decode("utf-8")
+            self.assertIn("const SHOW_DOMAIN_CHECK_HISTORY = false", html)
+
+    def test_stats_page_renders_flag_true_when_enabled(self):
+        os.environ["SHOW_DOMAIN_CHECK_HISTORY"] = "true"
+        app_module = self._reload_app()
+        with app_module.app.test_client() as client:
+            response = client.get("/stats")
+            self.assertEqual(response.status_code, 200)
+            html = response.data.decode("utf-8")
+            self.assertIn("const SHOW_DOMAIN_CHECK_HISTORY = true", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `SHOW_DOMAIN_CHECK_HISTORY` env flag (default `false`) gating a per-domain analytics view.
- New `GET /api/analytics/domain/<domain>?period=…` endpoint returning totals, validation ratio, source breakdown, and timeline for a single domain.
- Validation counts in **Top Validated Domains** become clickable when the flag is on, navigating to `/stats?domain=…` and re-rendering the dashboard scoped to that domain (with a clear-filter banner).
- InfluxDB query helpers (`get_requests_count`, `get_validation_ratio`, `get_hourly_requests`, `get_source_breakdown`) gain an optional `domain` filter; exposed via new `RequestLog.get_domain_*` convenience methods.

Closes #72.

## Scope notes
The issue's schema sketch mentions a `validation_duration` field. That isn't included here — adding it would require new timing instrumentation in `dnssec_validator.py` and would only benefit data written after rollout. Worth a follow-up if useful.

## Test plan
- [x] `pytest tests/` — 175 passing (15 new in `tests/unit/test_domain_history.py`)
- [x] `black app/ tests/`
- [x] `pylint app/*.py` — 9.99/10
- [ ] Manual: with `SHOW_DOMAIN_CHECK_HISTORY=true`, load `/stats`, click a count, confirm filter banner + scoped charts; verify `/stats` with flag off behaves exactly as before
- [ ] Manual: `curl /api/analytics/domain/bondit.dk?period=24h` returns expected payload; `curl` with flag off returns 404