### PR TITLE
Add CAA record validation (closes #35)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -14,6 +14,10 @@ FLASK_ENV=development
 # Enable/disable TLSA/DANE validation display in web UI (true/false)
 SHOW_VALIDATION_TLSA_DANE=false
 
+# Enable/disable CAA validation display in web UI (true/false)
+# CAA records are queried per RFC 8659 with tree-climbing inheritance.
+SHOW_VALIDATION_CAA=true
+
 # Show/hide BondIT attribution footer in web UI (true/false)
 SHOW_BONDIT_ATTRIBUTION=true
 

--- a/app/app.py
+++ b/app/app.py
@@ -465,6 +465,47 @@ tlsa_summary_model = api.model(
     },
 )
 
+caa_summary_model = api.model(
+    "CAASummary",
+    {
+        "status": fields.String(
+            required=True,
+            description="CAA validation status",
+            enum=["valid", "restricted", "records_found", "no_records", "error"],
+        ),
+        "records_found": fields.Integer(
+            required=True, description="Number of CAA records found"
+        ),
+        "authorized_cas": fields.List(
+            fields.String,
+            description="Certificate Authorities authorized for regular issuance",
+        ),
+        "wildcard_authorized_cas": fields.List(
+            fields.String,
+            description="Certificate Authorities authorized for wildcard issuance",
+        ),
+        "iodef_targets": fields.List(
+            fields.String,
+            description="IODEF reporting endpoints (e.g., mailto: or https://)",
+        ),
+        "inherited": fields.Boolean(
+            description="True when CAA records were inherited from a parent zone (RFC 8659)"
+        ),
+        "checked_domain": fields.String(
+            description="Domain at which CAA records were found (target or ancestor)"
+        ),
+        "issuance_allowed": fields.Boolean(
+            description="Whether certificate issuance is permitted by current CAA policy"
+        ),
+        "wildcard_issuance_allowed": fields.Boolean(
+            description="Whether wildcard certificate issuance is permitted by current CAA policy"
+        ),
+        "message": fields.String(
+            required=True, description="User-friendly status message"
+        ),
+    },
+)
+
 validation_result_model = api.model(
     "ValidationResult",
     {
@@ -486,6 +527,9 @@ validation_result_model = api.model(
         "records": fields.Nested(records_model, description="DNSSEC records found"),
         "tlsa_summary": fields.Nested(
             tlsa_summary_model, description="TLSA/DANE validation summary"
+        ),
+        "caa_summary": fields.Nested(
+            caa_summary_model, description="CAA (RFC 8659) validation summary"
         ),
         "errors": fields.List(
             fields.String, description="Any errors encountered during validation"
@@ -649,9 +693,11 @@ class DNSSECValidation(Resource):
         - DS record verification
         - RRSIG signature checking
         - TLSA/DANE validation (RFC 6698)
+        - CAA validation with tree-climbing inheritance (RFC 8659)
 
         Returns detailed validation results including status, trust chain,
-        TLSA validation summary, and all relevant DNSSEC records found.
+        TLSA validation summary, CAA validation summary, and all relevant
+        DNSSEC records found.
         """
         try:
             # Import domain utilities for URL parsing
@@ -1496,7 +1542,10 @@ def index():
     """Serve the main web interface"""
     logger.debug("Main web interface accessed")
     show_tlsa_dane = os.getenv("SHOW_VALIDATION_TLSA_DANE", "false").lower() == "true"
-    return render_template("index.html", show_tlsa_dane=show_tlsa_dane)
+    show_caa = os.getenv("SHOW_VALIDATION_CAA", "true").lower() == "true"
+    return render_template(
+        "index.html", show_tlsa_dane=show_tlsa_dane, show_caa=show_caa
+    )
 
 
 @app.route("/stats")
@@ -1517,7 +1566,13 @@ def check_domain_direct(domain):
     """Direct access like /bondit.dk - render page with pre-filled domain"""
     logger.info(f"Direct domain access: {domain}")
     show_tlsa_dane = os.getenv("SHOW_VALIDATION_TLSA_DANE", "false").lower() == "true"
-    return render_template("index.html", domain=domain, show_tlsa_dane=show_tlsa_dane)
+    show_caa = os.getenv("SHOW_VALIDATION_CAA", "true").lower() == "true"
+    return render_template(
+        "index.html",
+        domain=domain,
+        show_tlsa_dane=show_tlsa_dane,
+        show_caa=show_caa,
+    )
 
 
 @app.route("/<string:domain>/detailed")
@@ -1528,8 +1583,12 @@ def check_domain_detailed(domain):
     """Detailed DNSSEC analysis page like /bondit.dk/detailed"""
     logger.info(f"Detailed domain analysis access: {domain}")
     show_tlsa_dane = os.getenv("SHOW_VALIDATION_TLSA_DANE", "false").lower() == "true"
+    show_caa = os.getenv("SHOW_VALIDATION_CAA", "true").lower() == "true"
     return render_template(
-        "detailed.html", domain=domain, show_tlsa_dane=show_tlsa_dane
+        "detailed.html",
+        domain=domain,
+        show_tlsa_dane=show_tlsa_dane,
+        show_caa=show_caa,
     )
 
 

--- a/app/caa_validator.py
+++ b/app/caa_validator.py
@@ -1,0 +1,497 @@
+"""
+CAA (Certification Authority Authorization) record validator.
+
+Implements CAA record validation per RFC 8659, including tree-climbing
+to find inherited CAA records when none exist on the target domain.
+"""
+
+import logging
+import time
+from datetime import datetime
+
+import dns.resolver
+import dns.name
+import dns.rdatatype
+import dns.exception
+
+# Known CAA tags defined by RFC 8659 and IANA registry.
+KNOWN_CAA_TAGS = {"issue", "issuewild", "iodef", "contactemail", "contactphone"}
+
+# Tags relevant to certificate issuance authorization.
+ISSUANCE_TAGS = {"issue", "issuewild"}
+
+
+class CAAValidator:
+    """
+    CAA (Certification Authority Authorization) record validator.
+
+    Queries CAA records for a domain, walks up the DNS tree per RFC 8659
+    when no CAA records exist on the target, and produces a structured
+    validation result describing which CAs are authorized to issue
+    certificates for the domain.
+    """
+
+    def __init__(self, domain):
+        self.domain = domain.rstrip(".")
+        self.domain_name = dns.name.from_text(self.domain)
+
+    def validate_caa(self, timeout=10, max_levels=10):
+        """
+        Validate CAA records for the domain.
+
+        Performs RFC 8659 tree-climbing search: if the target domain has
+        no CAA records, parent domains are queried until a record is found
+        or the root is reached.
+
+        Args:
+            timeout: DNS query timeout in seconds.
+            max_levels: Maximum tree-climb iterations (safety bound).
+
+        Returns:
+            A dictionary with caa_status, caa_records, authorized_cas,
+            wildcard_authorized_cas, iodef_targets, errors/warnings and timing.
+        """
+        start_time = time.time()
+
+        result = {
+            "domain": self.domain,
+            "caa_status": "unknown",
+            "caa_records": [],
+            "authorized_cas": [],
+            "wildcard_authorized_cas": [],
+            "iodef_targets": [],
+            "issuance_allowed": True,
+            "wildcard_issuance_allowed": True,
+            "checked_domain": None,
+            "inherited": False,
+            "validation_time": datetime.utcnow().isoformat(),
+            "errors": [],
+            "warnings": [],
+            "query_time_ms": 0,
+        }
+
+        try:
+            records, checked_domain, inherited = self._query_caa_with_inheritance(
+                timeout=timeout, max_levels=max_levels
+            )
+            result["query_time_ms"] = round((time.time() - start_time) * 1000, 2)
+            result["checked_domain"] = checked_domain
+            result["inherited"] = inherited
+
+            if not records:
+                result["caa_status"] = "no_records"
+                result["warnings"].append(
+                    f"No CAA records found for {self.domain} or any parent zone"
+                )
+                return result
+
+            result["caa_records"] = records
+
+            # Analyse and summarise records.
+            analysis = self._analyze_records(records)
+            result["authorized_cas"] = analysis["authorized_cas"]
+            result["wildcard_authorized_cas"] = analysis["wildcard_authorized_cas"]
+            result["iodef_targets"] = analysis["iodef_targets"]
+            result["issuance_allowed"] = analysis["issuance_allowed"]
+            result["wildcard_issuance_allowed"] = analysis["wildcard_issuance_allowed"]
+
+            # Validate record syntax and accumulate warnings.
+            syntax_warnings = self._validate_syntax(records)
+            result["warnings"].extend(syntax_warnings)
+
+            if analysis["issuance_allowed"] and analysis["authorized_cas"]:
+                result["caa_status"] = "valid"
+            elif not analysis["issuance_allowed"]:
+                result["caa_status"] = "restricted"
+            else:
+                # Records exist but no issue/issuewild semantics extracted.
+                result["caa_status"] = "records_found"
+
+        except Exception as exc:  # noqa: BLE001 - keep validation non-fatal
+            result["errors"].append(f"CAA validation failed: {str(exc)}")
+            result["caa_status"] = "error"
+
+        return result
+
+    def _query_caa_with_inheritance(self, timeout=10, max_levels=10):
+        """
+        Query CAA records for the domain, climbing the DNS tree if absent.
+
+        Per RFC 8659 section 3, if a domain has no CAA record set, the
+        validator MUST walk up the tree until a record set is found or
+        the root is reached.
+
+        Returns:
+            (records, checked_domain, inherited) tuple.
+        """
+        current = self.domain_name
+        inherited = False
+        levels = 0
+
+        while levels < max_levels:
+            try:
+                records = self._query_caa_records(current.to_text(), timeout=timeout)
+            except dns.exception.DNSException as exc:
+                logging.warning(f"CAA query error for {current.to_text()}: {exc}")
+                records = []
+
+            if records:
+                return records, current.to_text(omit_final_dot=True), inherited
+
+            # Climb up one label.
+            if current == dns.name.root:
+                break
+            try:
+                parent = current.parent()
+            except dns.name.NoParent:
+                break
+
+            if parent == current:
+                break
+
+            current = parent
+            inherited = True
+            levels += 1
+
+        return [], current.to_text(omit_final_dot=True), inherited
+
+    def _query_caa_records(self, domain, timeout=10):
+        """Query CAA records for a specific domain."""
+        records = []
+        try:
+            resolver = dns.resolver.Resolver()
+            resolver.lifetime = timeout
+            resolver.timeout = timeout
+            resolver.use_edns(0, dns.flags.DO)
+
+            answer = resolver.resolve(domain, "CAA")
+
+            for rr in answer.rrset:
+                tag = self._decode_tag(rr.tag)
+                value = self._decode_value(rr.value)
+                record = {
+                    "name": domain.rstrip("."),
+                    "flags": int(rr.flags),
+                    "critical": bool(int(rr.flags) & 0x80),
+                    "tag": tag,
+                    "value": value,
+                    "ttl": answer.rrset.ttl,
+                }
+                records.append(record)
+
+            logging.info(f"Found {len(records)} CAA records for {domain}")
+            return records
+
+        except dns.resolver.NXDOMAIN:
+            logging.debug(f"NXDOMAIN for CAA query on {domain}")
+            return []
+        except dns.resolver.NoAnswer:
+            logging.debug(f"No CAA records for {domain}")
+            return []
+        except dns.resolver.NoNameservers as exc:
+            logging.warning(f"No nameservers responded for CAA on {domain}: {exc}")
+            return []
+        except dns.exception.Timeout:
+            logging.warning(f"Timeout querying CAA records for {domain}")
+            return []
+
+    @staticmethod
+    def _decode_tag(tag):
+        """Decode CAA tag which dnspython returns as bytes."""
+        if isinstance(tag, bytes):
+            try:
+                return tag.decode("ascii").lower()
+            except UnicodeDecodeError:
+                return tag.decode("ascii", errors="replace").lower()
+        return str(tag).lower()
+
+    @staticmethod
+    def _decode_value(value):
+        """Decode CAA value which dnspython returns as bytes."""
+        if isinstance(value, bytes):
+            try:
+                return value.decode("utf-8")
+            except UnicodeDecodeError:
+                return value.decode("utf-8", errors="replace")
+        return str(value)
+
+    def _analyze_records(self, records):
+        """Extract authorized CAs, IODEF targets, and issuance posture."""
+        authorized_cas = []
+        wildcard_authorized_cas = []
+        iodef_targets = []
+
+        explicit_issue = False
+        explicit_issuewild = False
+
+        # Whether any issue/issuewild record allows issuance.
+        issue_permits = False
+        issuewild_permits = False
+
+        for record in records:
+            tag = record["tag"]
+            raw_value = record["value"]
+            value = raw_value.strip()
+
+            if tag == "issue":
+                explicit_issue = True
+                ca = self._extract_ca_name(value)
+                if ca:
+                    authorized_cas.append(
+                        {
+                            "ca": ca,
+                            "raw_value": raw_value,
+                            "critical": record["critical"],
+                        }
+                    )
+                    issue_permits = True
+                # A bare ";" means no CA is permitted to issue.
+
+            elif tag == "issuewild":
+                explicit_issuewild = True
+                ca = self._extract_ca_name(value)
+                if ca:
+                    wildcard_authorized_cas.append(
+                        {
+                            "ca": ca,
+                            "raw_value": raw_value,
+                            "critical": record["critical"],
+                        }
+                    )
+                    issuewild_permits = True
+
+            elif tag == "iodef":
+                iodef_targets.append({"target": value, "critical": record["critical"]})
+
+        # RFC 8659: if no issue tag is present, issuance is implicitly allowed.
+        # If issue records are present, at least one must permit a CA.
+        issuance_allowed = (not explicit_issue) or issue_permits
+
+        # Wildcard issuance defaults to issue policy unless issuewild present.
+        if explicit_issuewild:
+            wildcard_issuance_allowed = issuewild_permits
+        else:
+            wildcard_issuance_allowed = issuance_allowed
+            # When issue allows a CA, the same CAs are authorized for wildcards
+            # absent an explicit issuewild record.
+            if issuance_allowed and not wildcard_authorized_cas:
+                wildcard_authorized_cas = list(authorized_cas)
+
+        return {
+            "authorized_cas": authorized_cas,
+            "wildcard_authorized_cas": wildcard_authorized_cas,
+            "iodef_targets": iodef_targets,
+            "issuance_allowed": issuance_allowed,
+            "wildcard_issuance_allowed": wildcard_issuance_allowed,
+        }
+
+    @staticmethod
+    def _extract_ca_name(value):
+        """
+        Extract the CA domain from an issue/issuewild value.
+
+        Per RFC 8659, the value is "<issuer-domain>[;param=value...]".
+        A bare ";" or empty value means no CA is authorized.
+        """
+        if not value or value.strip() == ";":
+            return None
+
+        ca = value.split(";", 1)[0].strip()
+        return ca if ca else None
+
+    def _validate_syntax(self, records):
+        """Validate CAA record syntax and return any warnings."""
+        warnings = []
+
+        for record in records:
+            tag = record["tag"]
+            flags = record["flags"]
+
+            if tag not in KNOWN_CAA_TAGS:
+                warnings.append(f"Unknown CAA tag '{tag}' on {record['name']}")
+
+            # Flags is an 8-bit field. Only the high bit (0x80) is defined
+            # as the critical flag. Other bits SHOULD be zero.
+            if flags & ~0x80:
+                warnings.append(
+                    f"Reserved CAA flag bits set on {record['name']} (flags={flags})"
+                )
+
+            if tag in ISSUANCE_TAGS and record["value"] is None:
+                warnings.append(f"Empty value for {tag} record on {record['name']}")
+
+        return warnings
+
+    def get_detailed_analysis(self, timeout=10, max_levels=10):
+        """Get detailed CAA analysis with security assessment and recommendations."""
+        basic_result = self.validate_caa(timeout=timeout, max_levels=max_levels)
+
+        detailed_result = {
+            **basic_result,
+            "detailed_analysis": {
+                "record_analysis": [],
+                "security_assessment": {},
+                "recommendations": [],
+                "troubleshooting": [],
+            },
+        }
+
+        try:
+            self._analyze_individual_records(detailed_result)
+            self._assess_security(detailed_result)
+            self._generate_recommendations(detailed_result)
+            self._generate_troubleshooting(detailed_result)
+        except Exception as exc:  # noqa: BLE001
+            detailed_result["detailed_analysis"]["errors"] = [
+                f"Detailed CAA analysis error: {str(exc)}"
+            ]
+
+        return detailed_result
+
+    def _analyze_individual_records(self, result):
+        """Add per-record analysis for detailed output."""
+        analyses = []
+        for record in result["caa_records"]:
+            record_analysis = {
+                "record": record,
+                "purpose": self._describe_tag(record["tag"]),
+                "is_known_tag": record["tag"] in KNOWN_CAA_TAGS,
+                "is_critical": record["critical"],
+            }
+            analyses.append(record_analysis)
+        result["detailed_analysis"]["record_analysis"] = analyses
+
+    @staticmethod
+    def _describe_tag(tag):
+        """Return a human-readable purpose string for a CAA tag."""
+        descriptions = {
+            "issue": "Authorizes a CA to issue regular certificates",
+            "issuewild": "Authorizes a CA to issue wildcard certificates",
+            "iodef": "Reporting endpoint for policy violations",
+            "contactemail": "Contact email address (extension)",
+            "contactphone": "Contact phone number (extension)",
+        }
+        return descriptions.get(tag, f"Unknown tag: {tag}")
+
+    def _assess_security(self, result):
+        """Assess CAA security posture and assign a score."""
+        assessment = {
+            "overall_score": 0,
+            "strengths": [],
+            "weaknesses": [],
+        }
+
+        score = 0
+
+        if result["caa_status"] == "valid":
+            score += 40
+            assessment["strengths"].append(
+                "CAA records authorize specific Certificate Authorities"
+            )
+        elif result["caa_status"] == "restricted":
+            score += 50
+            assessment["strengths"].append(
+                "CAA records explicitly forbid certificate issuance"
+            )
+        elif result["caa_status"] == "no_records":
+            assessment["weaknesses"].append(
+                "No CAA records found - any CA may issue certificates"
+            )
+
+        # Inheritance is informational, not a strength or weakness on its own.
+        if result["inherited"] and result["caa_records"]:
+            assessment["strengths"].append(
+                f"CAA policy inherited from parent zone {result['checked_domain']}"
+            )
+
+        # Wildcard handling.
+        if result["wildcard_authorized_cas"]:
+            score += 10
+            assessment["strengths"].append("Wildcard issuance policy defined")
+        elif result["caa_records"] and not result["wildcard_issuance_allowed"]:
+            score += 10
+            assessment["strengths"].append(
+                "Wildcard certificate issuance is restricted"
+            )
+
+        # IODEF reporting.
+        if result["iodef_targets"]:
+            score += 10
+            assessment["strengths"].append(
+                "IODEF reporting endpoint configured for policy violations"
+            )
+        elif result["caa_records"]:
+            assessment["weaknesses"].append("No IODEF reporting endpoint configured")
+
+        # Critical flag use - encourages strict enforcement.
+        if any(r["critical"] for r in result["caa_records"]):
+            score += 5
+            assessment["strengths"].append(
+                "At least one CAA record uses the critical flag"
+            )
+
+        if result["errors"]:
+            assessment["weaknesses"].extend(result["errors"])
+
+        assessment["overall_score"] = min(100, max(0, score))
+        result["detailed_analysis"]["security_assessment"] = assessment
+
+    def _generate_recommendations(self, result):
+        """Generate actionable CAA recommendations."""
+        recommendations = []
+
+        if result["caa_status"] == "no_records":
+            recommendations.extend(
+                [
+                    "Add CAA records to restrict which CAs may issue certificates",
+                    "Example: '0 issue \"letsencrypt.org\"' to authorize Let's Encrypt",
+                    "Use DNSSEC to protect CAA records from tampering",
+                ]
+            )
+        else:
+            if not result["iodef_targets"]:
+                recommendations.append(
+                    "Add an 'iodef' record to receive notifications of policy violations"
+                )
+            if (
+                not result["wildcard_authorized_cas"]
+                and result["wildcard_issuance_allowed"]
+            ):
+                recommendations.append(
+                    "Consider adding an explicit 'issuewild' record for wildcard issuance policy"
+                )
+            recommendations.append(
+                "Regularly review authorized CAs to match your actual issuance practices"
+            )
+            recommendations.append(
+                "Keep CAA records protected by DNSSEC to prevent downgrade attacks"
+            )
+
+        result["detailed_analysis"]["recommendations"] = recommendations
+
+    def _generate_troubleshooting(self, result):
+        """Generate troubleshooting guidance for common CAA misconfigurations."""
+        troubleshooting = []
+
+        if result["caa_status"] == "error":
+            troubleshooting.append(
+                "CAA query failed - verify DNS resolver connectivity"
+            )
+
+        if result["caa_records"]:
+            # Detect issue records that disallow everything via bare ";".
+            blockers = [
+                r
+                for r in result["caa_records"]
+                if r["tag"] in ISSUANCE_TAGS and r["value"].strip() == ";"
+            ]
+            if blockers:
+                troubleshooting.append(
+                    "One or more records use ';' to forbid all CA issuance - "
+                    "no certificates can be issued by any CA"
+                )
+
+        for warning in result["warnings"]:
+            troubleshooting.append(f"Warning: {warning}")
+
+        result["detailed_analysis"]["troubleshooting"] = troubleshooting

--- a/app/dnssec_validator.py
+++ b/app/dnssec_validator.py
@@ -12,6 +12,7 @@ import dns.query
 import dns.message
 
 from tlsa_validator import TLSAValidator
+from caa_validator import CAAValidator
 from domain_utils import get_fallback_domains, has_subdomain
 
 
@@ -26,6 +27,7 @@ class DNSSECValidator:
             "chain_of_trust": [],
             "records": {"dnskey": [], "ds": [], "rrsig": []},
             "tlsa_summary": None,  # Basic TLSA info for simple validation
+            "caa_summary": None,  # Basic CAA info for simple validation
             "errors": [],
         }
 
@@ -62,6 +64,13 @@ class DNSSECValidator:
         except Exception as e:
             logging.warning(f"TLSA check failed: {e}")
             # Don't fail the overall validation for TLSA issues
+
+        # Add basic CAA check (non-blocking)
+        try:
+            self._add_caa_summary()
+        except Exception as e:
+            logging.warning(f"CAA check failed: {e}")
+            # Don't fail the overall validation for CAA issues
 
         return self.results
 
@@ -429,6 +438,9 @@ class DNSSECValidator:
 
             # Add comprehensive TLSA analysis
             self._add_detailed_tlsa_analysis(detailed_result)
+
+            # Add comprehensive CAA analysis
+            self._add_detailed_caa_analysis(detailed_result)
 
         except Exception as e:
             detailed_result["detailed_analysis"]["errors"] = [
@@ -883,4 +895,99 @@ class DNSSECValidator:
                 "records_found": 0,
                 "dane_status": "error",
                 "message": "⚠️ TLSA check failed",
+            }
+
+    def _add_caa_summary(self):
+        """Add basic CAA summary to simple validation results"""
+        try:
+            caa_validator = CAAValidator(self.domain)
+            caa_result = caa_validator.validate_caa(timeout=5)
+
+            summary = {
+                "status": caa_result["caa_status"],
+                "records_found": len(caa_result["caa_records"]),
+                "authorized_cas": [
+                    ca["ca"] for ca in caa_result.get("authorized_cas", [])
+                ],
+                "wildcard_authorized_cas": [
+                    ca["ca"] for ca in caa_result.get("wildcard_authorized_cas", [])
+                ],
+                "iodef_targets": [
+                    t["target"] for t in caa_result.get("iodef_targets", [])
+                ],
+                "inherited": caa_result.get("inherited", False),
+                "checked_domain": caa_result.get("checked_domain"),
+                "issuance_allowed": caa_result.get("issuance_allowed", True),
+                "wildcard_issuance_allowed": caa_result.get(
+                    "wildcard_issuance_allowed", True
+                ),
+                "message": self._get_caa_status_message(caa_result["caa_status"]),
+            }
+
+            self.results["caa_summary"] = summary
+
+        except Exception as e:
+            logging.debug(f"CAA summary generation failed: {e}")
+            self.results["caa_summary"] = {
+                "status": "error",
+                "records_found": 0,
+                "authorized_cas": [],
+                "wildcard_authorized_cas": [],
+                "iodef_targets": [],
+                "inherited": False,
+                "checked_domain": None,
+                "issuance_allowed": True,
+                "wildcard_issuance_allowed": True,
+                "message": "⚠️ CAA check failed",
+            }
+
+    @staticmethod
+    def _get_caa_status_message(status):
+        """Get user-friendly message for CAA status"""
+        status_messages = {
+            "valid": "✅ CAA records authorize specific Certificate Authorities",
+            "restricted": "🔒 CAA records restrict certificate issuance",
+            "records_found": "📋 CAA records found",
+            "no_records": "💡 No CAA records found - any CA may issue certificates",
+            "error": "⚠️ CAA check failed",
+        }
+        return status_messages.get(status, "❓ CAA status unknown")
+
+    def _add_detailed_caa_analysis(self, result):
+        """Add comprehensive CAA analysis to detailed validation results"""
+        try:
+            caa_validator = CAAValidator(self.domain)
+            detailed_caa = caa_validator.get_detailed_analysis()
+
+            result["detailed_analysis"]["caa_analysis"] = detailed_caa
+
+            # Refresh basic CAA summary with detailed query results
+            result["caa_summary"] = {
+                "status": detailed_caa.get("caa_status", "unknown"),
+                "records_found": len(detailed_caa.get("caa_records", [])),
+                "authorized_cas": [
+                    ca["ca"] for ca in detailed_caa.get("authorized_cas", [])
+                ],
+                "wildcard_authorized_cas": [
+                    ca["ca"] for ca in detailed_caa.get("wildcard_authorized_cas", [])
+                ],
+                "iodef_targets": [
+                    t["target"] for t in detailed_caa.get("iodef_targets", [])
+                ],
+                "inherited": detailed_caa.get("inherited", False),
+                "checked_domain": detailed_caa.get("checked_domain"),
+                "issuance_allowed": detailed_caa.get("issuance_allowed", True),
+                "wildcard_issuance_allowed": detailed_caa.get(
+                    "wildcard_issuance_allowed", True
+                ),
+                "message": self._get_caa_status_message(
+                    detailed_caa.get("caa_status", "unknown")
+                ),
+            }
+
+        except Exception as e:
+            logging.warning(f"Detailed CAA analysis failed: {e}")
+            result["detailed_analysis"]["caa_analysis"] = {
+                "error": f"CAA analysis failed: {str(e)}",
+                "status": "error",
             }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -147,6 +147,28 @@ document.addEventListener('DOMContentLoaded', function() {
             html += '</div>';
         }
 
+        // Show CAA summary if available and feature is enabled
+        if (data.caa_summary && window.SHOW_CAA !== false) {
+            html += '<h3>📜 CAA Validation</h3>';
+            html += '<div class="chain-item">';
+            html += '<p><strong>Status:</strong> ' + escapeHTML(data.caa_summary.status) + '</p>';
+            html += '<p><strong>CAA Records Found:</strong> ' + escapeHTML(data.caa_summary.records_found) + '</p>';
+            if (data.caa_summary.inherited && data.caa_summary.checked_domain) {
+                html += '<p><strong>Inherited from:</strong> ' + escapeHTML(data.caa_summary.checked_domain) + '</p>';
+            }
+            if (data.caa_summary.authorized_cas && data.caa_summary.authorized_cas.length > 0) {
+                html += '<p><strong>Authorized CAs:</strong> ' + data.caa_summary.authorized_cas.map(escapeHTML).join(', ') + '</p>';
+            }
+            if (data.caa_summary.wildcard_authorized_cas && data.caa_summary.wildcard_authorized_cas.length > 0) {
+                html += '<p><strong>Wildcard CAs:</strong> ' + data.caa_summary.wildcard_authorized_cas.map(escapeHTML).join(', ') + '</p>';
+            }
+            if (data.caa_summary.iodef_targets && data.caa_summary.iodef_targets.length > 0) {
+                html += '<p><strong>IODEF Targets:</strong> ' + data.caa_summary.iodef_targets.map(escapeHTML).join(', ') + '</p>';
+            }
+            html += '<p style="margin: 10px 0; padding: 10px; background: #f8f9fa; border-radius: 4px; font-style: italic;">' + escapeHTML(data.caa_summary.message) + '</p>';
+            html += '</div>';
+        }
+
         if (data.errors && data.errors.length > 0) {
             html += '<h3>Errors</h3>';
             data.errors.forEach(function(error) {

--- a/app/templates/detailed.html
+++ b/app/templates/detailed.html
@@ -225,6 +225,7 @@
     <script>
         // Feature flags
         window.SHOW_TLSA_DANE = {{ 'true' if show_tlsa_dane else 'false' }};
+        window.SHOW_CAA = {{ 'true' if show_caa else 'false' }};
         
         let currentDomain = {{ domain|tojson if domain else "null" }};
         
@@ -576,7 +577,99 @@
                     </div>
                 `;
             }
-            
+
+            // CAA Analysis (comprehensive) - only show if feature is enabled
+            if (window.SHOW_CAA !== false && data.detailed_analysis && data.detailed_analysis.caa_analysis) {
+                const caaAnalysis = data.detailed_analysis.caa_analysis;
+                html += `
+                    <div class="section-header">📜 CAA Record Analysis</div>
+                    <div class="subsection">
+                `;
+
+                if (caaAnalysis.error) {
+                    html += `<p style="color: #dc3545;">❌ CAA analysis failed: ${caaAnalysis.error}</p>`;
+                } else {
+                    html += `<p><strong>Status:</strong> ${caaAnalysis.caa_status || 'unknown'}</p>`;
+                    if (caaAnalysis.checked_domain) {
+                        html += `<p><strong>Records Queried At:</strong> ${caaAnalysis.checked_domain}${caaAnalysis.inherited ? ' <em>(inherited from parent zone)</em>' : ''}</p>`;
+                    }
+
+                    if (caaAnalysis.caa_records && caaAnalysis.caa_records.length > 0) {
+                        html += `
+                            <h4>📋 CAA Records (${caaAnalysis.caa_records.length} found)</h4>
+                            <div style="overflow-x: auto;">
+                                <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
+                                    <tr style="background: #e9ecef;">
+                                        <th style="padding: 8px; border: 1px solid #dee2e6;">Flags</th>
+                                        <th style="padding: 8px; border: 1px solid #dee2e6;">Tag</th>
+                                        <th style="padding: 8px; border: 1px solid #dee2e6;">Value</th>
+                                        <th style="padding: 8px; border: 1px solid #dee2e6;">Critical</th>
+                                    </tr>
+                        `;
+                        caaAnalysis.caa_records.forEach(record => {
+                            html += `
+                                <tr>
+                                    <td style="padding: 8px; border: 1px solid #dee2e6;">${record.flags}</td>
+                                    <td style="padding: 8px; border: 1px solid #dee2e6;">${record.tag}</td>
+                                    <td style="padding: 8px; border: 1px solid #dee2e6; font-family: monospace; font-size: 0.9em;">${record.value}</td>
+                                    <td style="padding: 8px; border: 1px solid #dee2e6;">${record.critical ? 'Yes' : 'No'}</td>
+                                </tr>
+                            `;
+                        });
+                        html += '</table></div>';
+                    } else {
+                        html += '<h4>📋 CAA Records</h4><p style="color: #6c757d;">💡 No CAA records found</p>';
+                    }
+
+                    if (caaAnalysis.authorized_cas && caaAnalysis.authorized_cas.length > 0) {
+                        html += '<h4>✅ Authorized Certificate Authorities</h4><ul>';
+                        caaAnalysis.authorized_cas.forEach(ca => {
+                            html += `<li>${ca.ca}${ca.critical ? ' <em>(critical)</em>' : ''}</li>`;
+                        });
+                        html += '</ul>';
+                    }
+
+                    if (caaAnalysis.wildcard_authorized_cas && caaAnalysis.wildcard_authorized_cas.length > 0) {
+                        html += '<h4>✳️ Wildcard Authorized CAs</h4><ul>';
+                        caaAnalysis.wildcard_authorized_cas.forEach(ca => {
+                            html += `<li>${ca.ca}${ca.critical ? ' <em>(critical)</em>' : ''}</li>`;
+                        });
+                        html += '</ul>';
+                    }
+
+                    if (caaAnalysis.iodef_targets && caaAnalysis.iodef_targets.length > 0) {
+                        html += '<h4>📨 IODEF Reporting</h4><ul>';
+                        caaAnalysis.iodef_targets.forEach(t => {
+                            html += `<li>${t.target}${t.critical ? ' <em>(critical)</em>' : ''}</li>`;
+                        });
+                        html += '</ul>';
+                    }
+                }
+
+                if (caaAnalysis.detailed_analysis && caaAnalysis.detailed_analysis.recommendations && caaAnalysis.detailed_analysis.recommendations.length > 0) {
+                    html += `
+                        <div style="background: #d1ecf1; border: 1px solid #b8daff; border-radius: 5px; padding: 15px; margin: 15px 0;">
+                            <h4 style="color: #0c5460; margin-bottom: 10px;">💡 CAA Recommendations</h4>
+                            <ul style="margin: 0; color: #0c5460;">
+                    `;
+                    caaAnalysis.detailed_analysis.recommendations.forEach(rec => {
+                        html += `<li>${rec}</li>`;
+                    });
+                    html += '</ul></div>';
+                }
+
+                html += '</div>';
+            } else if (window.SHOW_CAA !== false && data.caa_summary) {
+                html += `
+                    <div class="section-header">📜 CAA Summary</div>
+                    <div class="subsection">
+                        <p><strong>Status:</strong> ${data.caa_summary.status}</p>
+                        <p><strong>CAA Records Found:</strong> ${data.caa_summary.records_found}</p>
+                        <p style="margin: 10px 0; padding: 10px; background: #f8f9fa; border-radius: 4px; font-style: italic;">${data.caa_summary.message}</p>
+                    </div>
+                `;
+            }
+
             // Raw DNS Queries
             if (data.detailed_analysis && data.detailed_analysis.raw_dns_queries) {
                 html += `

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,6 +26,7 @@
     <script>
         // Feature flags
         window.SHOW_TLSA_DANE = {{ 'true' if show_tlsa_dane else 'false' }};
+        window.SHOW_CAA = {{ 'true' if show_caa else 'false' }};
         
         // Google Analytics configuration
         window.GA_ENABLED = {{ 'true' if ga_enabled else 'false' }};

--- a/tests/unit/test_caa_validator.py
+++ b/tests/unit/test_caa_validator.py
@@ -1,0 +1,474 @@
+"""
+Unit tests for CAAValidator class.
+Tests CAA (RFC 8659) validation logic with mocked DNS responses.
+"""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "app"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "fixtures"))
+
+from caa_validator import (  # noqa: E402  pylint: disable=wrong-import-position
+    CAAValidator,
+    KNOWN_CAA_TAGS,
+    ISSUANCE_TAGS,
+)
+
+
+def _make_caa_rr(tag, value, flags=0):
+    """Helper to build a mock CAA rdata object."""
+    rr = MagicMock()
+    rr.flags = flags
+    rr.tag = tag.encode("ascii") if isinstance(tag, str) else tag
+    rr.value = value.encode("utf-8") if isinstance(value, str) else value
+    return rr
+
+
+def _make_answer(rrs, ttl=300):
+    """Helper to build a mock dnspython answer object."""
+    rrset = MagicMock()
+    rrset.ttl = ttl
+    rrset.__iter__ = lambda self: iter(rrs)
+    answer = MagicMock()
+    answer.rrset = rrset
+    return answer
+
+
+@pytest.mark.unit
+class TestCAAValidatorInit:
+    """Test CAAValidator initialization and constants."""
+
+    def test_init_with_domain(self):
+        validator = CAAValidator("bondit.dk")
+        assert validator.domain == "bondit.dk"
+
+    def test_init_strips_trailing_dot(self):
+        validator = CAAValidator("bondit.dk.")
+        assert validator.domain == "bondit.dk"
+
+    def test_known_tags_present(self):
+        assert "issue" in KNOWN_CAA_TAGS
+        assert "issuewild" in KNOWN_CAA_TAGS
+        assert "iodef" in KNOWN_CAA_TAGS
+
+    def test_issuance_tags(self):
+        assert "issue" in ISSUANCE_TAGS
+        assert "issuewild" in ISSUANCE_TAGS
+        assert "iodef" not in ISSUANCE_TAGS
+
+
+@pytest.mark.unit
+class TestCAAQuery:
+    """Test CAA DNS query methods."""
+
+    @patch("dns.resolver.Resolver")
+    def test_query_caa_records_success(self, mock_resolver_class):
+        validator = CAAValidator("bondit.dk")
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+
+        rr = _make_caa_rr("issue", "letsencrypt.org", flags=0)
+        mock_resolver.resolve.return_value = _make_answer([rr])
+
+        records = validator._query_caa_records("bondit.dk")
+
+        assert len(records) == 1
+        assert records[0]["tag"] == "issue"
+        assert records[0]["value"] == "letsencrypt.org"
+        assert records[0]["critical"] is False
+        assert records[0]["flags"] == 0
+
+    @patch("dns.resolver.Resolver")
+    def test_query_caa_records_critical_flag(self, mock_resolver_class):
+        validator = CAAValidator("bondit.dk")
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+
+        rr = _make_caa_rr("issue", "digicert.com", flags=128)
+        mock_resolver.resolve.return_value = _make_answer([rr])
+
+        records = validator._query_caa_records("bondit.dk")
+
+        assert records[0]["critical"] is True
+        assert records[0]["flags"] == 128
+
+    @patch("dns.resolver.Resolver")
+    def test_query_caa_nxdomain(self, mock_resolver_class):
+        import dns.resolver
+
+        validator = CAAValidator("example.test")
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+        mock_resolver.resolve.side_effect = dns.resolver.NXDOMAIN()
+
+        assert validator._query_caa_records("example.test") == []
+
+    @patch("dns.resolver.Resolver")
+    def test_query_caa_noanswer(self, mock_resolver_class):
+        import dns.resolver
+
+        validator = CAAValidator("example.test")
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+        mock_resolver.resolve.side_effect = dns.resolver.NoAnswer()
+
+        assert validator._query_caa_records("example.test") == []
+
+
+@pytest.mark.unit
+class TestCAAInheritance:
+    """Test RFC 8659 tree-climbing inheritance."""
+
+    def test_inheritance_no_records_at_target_uses_parent(self):
+        validator = CAAValidator("sub.example.dk")
+
+        sub_records = []
+        parent_records = [
+            {
+                "name": "example.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            }
+        ]
+
+        call_results = {"sub.example.dk.": sub_records, "example.dk.": parent_records}
+
+        def fake_query(domain, timeout=10):
+            # dnspython names append a trailing dot - normalise.
+            key = domain if domain.endswith(".") else domain + "."
+            return call_results.get(key, [])
+
+        with patch.object(validator, "_query_caa_records", side_effect=fake_query):
+            records, checked, inherited = validator._query_caa_with_inheritance()
+
+        assert len(records) == 1
+        assert checked == "example.dk"
+        assert inherited is True
+
+    def test_inheritance_returns_target_records_when_present(self):
+        validator = CAAValidator("bondit.dk")
+
+        target_records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            }
+        ]
+
+        with patch.object(validator, "_query_caa_records", return_value=target_records):
+            records, checked, inherited = validator._query_caa_with_inheritance()
+
+        assert records == target_records
+        assert checked == "bondit.dk"
+        assert inherited is False
+
+    def test_inheritance_stops_at_root(self):
+        validator = CAAValidator("nothing.invalid")
+
+        with patch.object(validator, "_query_caa_records", return_value=[]):
+            records, _, _ = validator._query_caa_with_inheritance()
+
+        assert records == []
+
+
+@pytest.mark.unit
+class TestCAAAnalysis:
+    """Test CAA record analysis logic."""
+
+    def test_analyze_records_basic_issue(self):
+        validator = CAAValidator("bondit.dk")
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            }
+        ]
+        analysis = validator._analyze_records(records)
+        assert analysis["issuance_allowed"] is True
+        assert analysis["authorized_cas"][0]["ca"] == "letsencrypt.org"
+        # Without explicit issuewild, wildcard inherits issue policy.
+        assert analysis["wildcard_authorized_cas"][0]["ca"] == "letsencrypt.org"
+
+    def test_analyze_records_issuewild_separate(self):
+        validator = CAAValidator("bondit.dk")
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            },
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issuewild",
+                "value": "digicert.com",
+                "ttl": 300,
+            },
+        ]
+        analysis = validator._analyze_records(records)
+        assert analysis["authorized_cas"][0]["ca"] == "letsencrypt.org"
+        assert analysis["wildcard_authorized_cas"][0]["ca"] == "digicert.com"
+        assert analysis["wildcard_issuance_allowed"] is True
+
+    def test_analyze_records_blocking_issue(self):
+        validator = CAAValidator("bondit.dk")
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": ";",
+                "ttl": 300,
+            }
+        ]
+        analysis = validator._analyze_records(records)
+        assert analysis["issuance_allowed"] is False
+        assert analysis["authorized_cas"] == []
+
+    def test_analyze_records_issuewild_blocks_wildcards(self):
+        validator = CAAValidator("bondit.dk")
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            },
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issuewild",
+                "value": ";",
+                "ttl": 300,
+            },
+        ]
+        analysis = validator._analyze_records(records)
+        assert analysis["issuance_allowed"] is True
+        assert analysis["wildcard_issuance_allowed"] is False
+        assert analysis["wildcard_authorized_cas"] == []
+
+    def test_analyze_records_iodef(self):
+        validator = CAAValidator("bondit.dk")
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "iodef",
+                "value": "mailto:security@bondit.dk",
+                "ttl": 300,
+            }
+        ]
+        analysis = validator._analyze_records(records)
+        assert analysis["iodef_targets"][0]["target"] == "mailto:security@bondit.dk"
+
+    def test_extract_ca_name_with_params(self):
+        result = CAAValidator._extract_ca_name(
+            "letsencrypt.org;validationmethods=dns-01"
+        )
+        assert result == "letsencrypt.org"
+
+    def test_extract_ca_name_bare_semicolon(self):
+        assert CAAValidator._extract_ca_name(";") is None
+
+    def test_extract_ca_name_empty(self):
+        assert CAAValidator._extract_ca_name("") is None
+
+    def test_decode_tag_bytes(self):
+        assert CAAValidator._decode_tag(b"ISSUE") == "issue"
+
+    def test_decode_value_bytes(self):
+        assert CAAValidator._decode_value(b"letsencrypt.org") == "letsencrypt.org"
+
+
+@pytest.mark.unit
+class TestCAAValidateCAA:
+    """Test the top-level validate_caa method."""
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_validate_caa_no_records(self, mock_query):
+        mock_query.return_value = ([], "bondit.dk", False)
+        validator = CAAValidator("bondit.dk")
+        result = validator.validate_caa()
+        assert result["caa_status"] == "no_records"
+        assert result["caa_records"] == []
+        assert len(result["warnings"]) > 0
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_validate_caa_valid(self, mock_query):
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            }
+        ]
+        mock_query.return_value = (records, "bondit.dk", False)
+        validator = CAAValidator("bondit.dk")
+        result = validator.validate_caa()
+        assert result["caa_status"] == "valid"
+        assert result["issuance_allowed"] is True
+        assert "letsencrypt.org" in [ca["ca"] for ca in result["authorized_cas"]]
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_validate_caa_restricted(self, mock_query):
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": ";",
+                "ttl": 300,
+            }
+        ]
+        mock_query.return_value = (records, "bondit.dk", False)
+        validator = CAAValidator("bondit.dk")
+        result = validator.validate_caa()
+        assert result["caa_status"] == "restricted"
+        assert result["issuance_allowed"] is False
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_validate_caa_error_handled(self, mock_query):
+        mock_query.side_effect = RuntimeError("dns boom")
+        validator = CAAValidator("bondit.dk")
+        result = validator.validate_caa()
+        assert result["caa_status"] == "error"
+        assert len(result["errors"]) > 0
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_validate_caa_inherited_flag(self, mock_query):
+        records = [
+            {
+                "name": "example.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            }
+        ]
+        mock_query.return_value = (records, "example.dk", True)
+        validator = CAAValidator("sub.example.dk")
+        result = validator.validate_caa()
+        assert result["inherited"] is True
+        assert result["checked_domain"] == "example.dk"
+
+
+@pytest.mark.unit
+class TestCAASyntaxValidation:
+    """Test CAA syntax validation."""
+
+    def test_unknown_tag_warning(self):
+        validator = CAAValidator("bondit.dk")
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "futuretag",
+                "value": "x",
+                "ttl": 300,
+            }
+        ]
+        warnings = validator._validate_syntax(records)
+        assert any("Unknown CAA tag" in w for w in warnings)
+
+    def test_reserved_flags_warning(self):
+        validator = CAAValidator("bondit.dk")
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0x40,  # Reserved bit set
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            }
+        ]
+        warnings = validator._validate_syntax(records)
+        assert any("Reserved CAA flag" in w for w in warnings)
+
+
+@pytest.mark.unit
+class TestCAADetailedAnalysis:
+    """Test the detailed analysis output."""
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_detailed_analysis_keys(self, mock_query):
+        mock_query.return_value = ([], "bondit.dk", False)
+        validator = CAAValidator("bondit.dk")
+        detailed = validator.get_detailed_analysis()
+
+        assert "detailed_analysis" in detailed
+        assert "record_analysis" in detailed["detailed_analysis"]
+        assert "security_assessment" in detailed["detailed_analysis"]
+        assert "recommendations" in detailed["detailed_analysis"]
+        assert "troubleshooting" in detailed["detailed_analysis"]
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_detailed_analysis_no_records_recommendations(self, mock_query):
+        mock_query.return_value = ([], "bondit.dk", False)
+        validator = CAAValidator("bondit.dk")
+        detailed = validator.get_detailed_analysis()
+        recs = detailed["detailed_analysis"]["recommendations"]
+        assert any("Add CAA records" in r for r in recs)
+
+    @patch.object(CAAValidator, "_query_caa_with_inheritance")
+    def test_detailed_analysis_score_for_valid(self, mock_query):
+        records = [
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "issue",
+                "value": "letsencrypt.org",
+                "ttl": 300,
+            },
+            {
+                "name": "bondit.dk",
+                "flags": 0,
+                "critical": False,
+                "tag": "iodef",
+                "value": "mailto:security@bondit.dk",
+                "ttl": 300,
+            },
+        ]
+        mock_query.return_value = (records, "bondit.dk", False)
+        validator = CAAValidator("bondit.dk")
+        detailed = validator.get_detailed_analysis()
+        assessment = detailed["detailed_analysis"]["security_assessment"]
+        assert assessment["overall_score"] > 0
+        assert any("authorize" in s.lower() for s in assessment["strengths"])
+
+    def test_describe_tag_known(self):
+        assert "wildcard" in CAAValidator._describe_tag("issuewild").lower()
+
+    def test_describe_tag_unknown(self):
+        assert "Unknown" in CAAValidator._describe_tag("xyz")

--- a/tests/unit/test_caa_validator.py
+++ b/tests/unit/test_caa_validator.py
@@ -334,7 +334,8 @@ class TestCAAValidateCAA:
         result = validator.validate_caa()
         assert result["caa_status"] == "valid"
         assert result["issuance_allowed"] is True
-        assert "letsencrypt.org" in [ca["ca"] for ca in result["authorized_cas"]]
+        authorized_ca_names = [ca["ca"] for ca in result["authorized_cas"]]
+        assert authorized_ca_names == ["letsencrypt.org"]
 
     @patch.object(CAAValidator, "_query_caa_with_inheritance")
     def test_validate_caa_restricted(self, mock_query):


### PR DESCRIPTION
## Summary
- Adds `CAAValidator` (RFC 8659) with tree-climbing inheritance — walks up the DNS tree if the target domain has no CAA record set.
- Wires CAA into both basic (`caa_summary`) and detailed (`caa_analysis`) DNSSEC responses, plus the web UI.
- Gated by `SHOW_VALIDATION_CAA` (default `true`).
- Recognizes `issue`, `issuewild`, `iodef`, `contactemail`, `contactphone` tags. Reports authorized CAs, wildcard policy, IODEF endpoints, critical-flag use, and security-posture recommendations.

Closes #35.

## Test plan
- [x] 33 new tests in `tests/unit/test_caa_validator.py` (mocked DNS responses, inheritance, syntax validation, detailed analysis)
- [x] Full suite: 208 passing
- [x] black formatted, pylint 9.98/10
- [ ] Manual: validate `bondit.dk` and a domain with no CAA records; confirm UI shows expected sections