### PR TITLE
Add response caching with Flask-Caching (closes #36)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -68,6 +68,31 @@ RATE_LIMIT_WEB_MINUTE=50
 RATE_LIMIT_WEB_HOUR=500
 
 # ========================================
+# Caching Configuration
+# ========================================
+# Enable response caching for DNSSEC validation results (true/false)
+# When true, repeated validations of the same domain return cached results
+# within the configured TTL, reducing DNS query load and latency.
+CACHE_ENABLED=false
+
+# Cache backend: 'simple' (in-memory) or 'redis'
+# - simple: Lightweight in-process cache, no external service required
+# - redis:  Shared cache backed by a Redis server (CACHE_REDIS_URL required)
+CACHE_BACKEND=simple
+
+# Default cache TTL in seconds for cached validation results
+CACHE_DEFAULT_TIMEOUT=300
+
+# Optional: Redis connection URL (only used when CACHE_BACKEND=redis)
+# Example: redis://redis:6379/0
+# CACHE_REDIS_URL=redis://localhost:6379/0
+
+# Clamp the cache TTL to the smallest DNS record TTL observed in the
+# validation result (true/false). When enabled, the effective TTL becomes
+# min(CACHE_DEFAULT_TIMEOUT, smallest_observed_dns_ttl).
+CACHE_RESPECT_DNS_TTL=true
+
+# ========================================
 # CORS Configuration
 # ========================================
 # Comma-separated list of allowed origins for production

--- a/app/app.py
+++ b/app/app.py
@@ -1,11 +1,13 @@
 import logging
 import os
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
 import psutil
 from flask import Flask, jsonify, render_template, request, g
+from flask_caching import Cache
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -51,6 +53,53 @@ Talisman(
 )
 
 
+# Caching configuration from environment variables
+def get_cache_config():
+    """Build Flask-Caching configuration from environment variables.
+
+    Returns a tuple of (config_dict, enabled, respect_dns_ttl) where:
+      - config_dict: a dict suitable for ``Cache(app, config=...)``
+      - enabled: boolean indicating whether caching is enabled
+      - respect_dns_ttl: boolean indicating whether to clamp the cache TTL
+        to the smallest DNS record TTL observed in the validation result.
+    """
+    enabled = os.getenv("CACHE_ENABLED", "false").lower() in ["true", "1", "yes"]
+    backend = os.getenv("CACHE_BACKEND", "simple").lower()
+    try:
+        default_timeout = int(os.getenv("CACHE_DEFAULT_TIMEOUT", "300"))
+    except ValueError:
+        default_timeout = 300
+    respect_dns_ttl = os.getenv("CACHE_RESPECT_DNS_TTL", "true").lower() in [
+        "true",
+        "1",
+        "yes",
+    ]
+
+    # Map backend identifier to Flask-Caching CACHE_TYPE
+    backend_map = {
+        "simple": "SimpleCache",
+        "redis": "RedisCache",
+        "null": "NullCache",
+    }
+    cache_type = backend_map.get(backend, "SimpleCache")
+
+    # If caching is disabled we still build a NullCache instance so that the
+    # rest of the code can safely invoke cache operations without conditionals.
+    if not enabled:
+        cache_type = "NullCache"
+
+    config = {
+        "CACHE_TYPE": cache_type,
+        "CACHE_DEFAULT_TIMEOUT": default_timeout,
+    }
+
+    redis_url = os.getenv("CACHE_REDIS_URL")
+    if redis_url:
+        config["CACHE_REDIS_URL"] = redis_url
+
+    return config, enabled, respect_dns_ttl
+
+
 # Rate limiting configuration from environment variables
 def get_rate_limits():
     return {
@@ -73,6 +122,196 @@ limiter = Limiter(
         f"{rate_limits['global_hour']} per hour",
     ],
 )
+
+# Caching: initialise Flask-Caching with the configured backend. When the
+# feature flag is disabled we still create a NullCache instance so that the
+# cache API can be invoked unconditionally throughout the code base.
+_cache_config, CACHE_ENABLED, CACHE_RESPECT_DNS_TTL = get_cache_config()
+try:
+    cache = Cache(app, config=_cache_config)
+except Exception as _cache_init_exc:  # pylint: disable=broad-except
+    # Fall back to NullCache when the requested backend cannot be constructed
+    # (e.g. CACHE_BACKEND=redis but the redis package is not installed).
+    logging.getLogger(__name__).warning(
+        "Failed to initialise cache backend %s: %s. Falling back to NullCache.",
+        _cache_config.get("CACHE_TYPE"),
+        _cache_init_exc,
+    )
+    cache = Cache(app, config={"CACHE_TYPE": "NullCache"})
+
+
+# Cache hit/miss statistics. These counters are in-process and reset whenever
+# the worker restarts; they are intentionally not persisted because the cache
+# itself is per-process when using SimpleCache.
+class CacheStats:
+    """Thread-safe hit/miss counters for the validation cache."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.hits = 0
+        self.misses = 0
+        self.sets = 0
+        self.skipped = 0  # results that were intentionally not cached
+
+    def record_hit(self):
+        with self._lock:
+            self.hits += 1
+
+    def record_miss(self):
+        with self._lock:
+            self.misses += 1
+
+    def record_set(self):
+        with self._lock:
+            self.sets += 1
+
+    def record_skipped(self):
+        with self._lock:
+            self.skipped += 1
+
+    def reset(self):
+        with self._lock:
+            self.hits = 0
+            self.misses = 0
+            self.sets = 0
+            self.skipped = 0
+
+    def as_dict(self):
+        with self._lock:
+            total = self.hits + self.misses
+            hit_ratio = (self.hits / total) if total else 0.0
+            return {
+                "enabled": CACHE_ENABLED,
+                "backend": _cache_config.get("CACHE_TYPE", "NullCache"),
+                "default_timeout": _cache_config.get("CACHE_DEFAULT_TIMEOUT"),
+                "respect_dns_ttl": CACHE_RESPECT_DNS_TTL,
+                "hits": self.hits,
+                "misses": self.misses,
+                "sets": self.sets,
+                "skipped": self.skipped,
+                "total_lookups": total,
+                "hit_ratio": round(hit_ratio, 4),
+            }
+
+
+cache_stats = CacheStats()
+
+
+def _cache_key(domain, request_type):
+    """Build a stable cache key for a (domain, request_type) tuple."""
+    return f"dnssec:{request_type}:{domain.lower()}"
+
+
+def _is_cacheable_result(result):
+    """Return True when a validation result is safe to cache.
+
+    We deliberately skip 4xx/5xx-style errors so that transient failures do
+    not poison the cache and so that callers see fresh state once an issue
+    is resolved.
+    """
+    if not isinstance(result, dict):
+        return False
+    status = str(result.get("status", "")).lower()
+    if status == "error":
+        return False
+    if result.get("errors"):
+        # Treat any populated errors list as a non-cacheable result.
+        return False
+    return True
+
+
+def _extract_min_dns_ttl(result):
+    """Best-effort extraction of the smallest DNS record TTL from a result.
+
+    Returns None when no usable TTL information is present. The function
+    inspects DNSKEY/DS/RRSIG record structures (where present) and falls
+    back to the standard ``ttl`` field if exposed.
+    """
+    min_ttl = None
+    records = result.get("records") if isinstance(result, dict) else None
+    candidates = []
+    if isinstance(records, dict):
+        for key in ("dnskey", "ds", "rrsig"):
+            entries = records.get(key) or []
+            if isinstance(entries, list):
+                for entry in entries:
+                    if isinstance(entry, dict):
+                        # Several historical names for the TTL field
+                        for field in ("ttl", "original_ttl"):
+                            value = entry.get(field)
+                            if isinstance(value, (int, float)) and value > 0:
+                                candidates.append(int(value))
+    top_ttl = result.get("ttl") if isinstance(result, dict) else None
+    if isinstance(top_ttl, (int, float)) and top_ttl > 0:
+        candidates.append(int(top_ttl))
+    if candidates:
+        min_ttl = min(candidates)
+    return min_ttl
+
+
+def _resolve_timeout(result):
+    """Pick the effective cache timeout for a validation result."""
+    default_timeout = _cache_config.get("CACHE_DEFAULT_TIMEOUT", 300)
+    if not CACHE_RESPECT_DNS_TTL:
+        return default_timeout
+    min_ttl = _extract_min_dns_ttl(result)
+    if min_ttl is None:
+        return default_timeout
+    # Use the tighter of the two values so that we never serve stale data
+    # beyond the DNS record's own TTL.
+    return max(1, min(default_timeout, min_ttl))
+
+
+def validate_with_cache(domain, request_type, validator_fn):
+    """Run ``validator_fn`` for ``domain`` honouring the cache.
+
+    Args:
+        domain: The (already extracted/normalised) domain to validate.
+        request_type: Either ``"basic"`` or ``"detailed"``.
+        validator_fn: Callable returning a validation result dict.
+
+    Returns:
+        The validation result, either from cache or freshly produced.
+    """
+    if not CACHE_ENABLED:
+        return validator_fn()
+
+    key = _cache_key(domain, request_type)
+    cached = cache.get(key)
+    if cached is not None:
+        cache_stats.record_hit()
+        # Surface the cached marker for observability; we copy so callers do
+        # not accidentally mutate the cached value.
+        cached_copy = dict(cached)
+        cached_copy["cached"] = True
+        return cached_copy
+
+    cache_stats.record_miss()
+    result = validator_fn()
+
+    if _is_cacheable_result(result):
+        timeout = _resolve_timeout(result)
+        cache.set(key, result, timeout=timeout)
+        cache_stats.record_set()
+    else:
+        cache_stats.record_skipped()
+
+    return result
+
+
+def invalidate_cached_domain(domain):
+    """Remove every cached validation entry for ``domain``.
+
+    Returns the number of entries that were deleted.
+    """
+    removed = 0
+    for request_type in ("basic", "detailed"):
+        key = _cache_key(domain, request_type)
+        # cache.delete may return None on backends that do not surface a
+        # truthy value; treat any successful call as a removal attempt.
+        if cache.delete(key):
+            removed += 1
+    return removed
 
 
 # Configure logging with environment variable support
@@ -269,6 +508,7 @@ def log_request(response):
         # Determine if this is an internal request (analytics, stats, etc.)
         internal_paths = [
             "/api/analytics/",
+            "/api/cache/",
             "/health",
             "/api/docs",
         ]
@@ -675,6 +915,9 @@ ns_validate = api.namespace("validate", description="DNSSEC validation operation
 ns_analytics = api.namespace(
     "analytics", description="Analytics and statistics operations"
 )
+ns_cache = api.namespace(
+    "cache", description="Validation cache inspection and invalidation"
+)
 
 # Analytics API models
 analytics_overview_model = api.model(
@@ -773,11 +1016,17 @@ class DNSSECValidation(Resource):
             logger.debug(f"Extracted domain for validation: {domain}")
 
             logger.debug(f"Starting DNSSEC validation for domain: {domain}")
-            validator = DNSSECValidator(domain)
-            result = validator.validate()
-            attach_idn_forms(result, domain)
+
+            def _run_validation():
+                validator = DNSSECValidator(domain)
+                res = validator.validate()
+                attach_idn_forms(res, domain)
+                return res
+
+            result = validate_with_cache(domain, "basic", _run_validation)
             logger.info(
-                f"DNSSEC validation completed for {domain} with status: {result.get('status', 'unknown')}"
+                f"DNSSEC validation completed for {domain} with status: "
+                f"{result.get('status', 'unknown')} (cached={result.get('cached', False)})"
             )
             return result, 200
 
@@ -853,11 +1102,17 @@ class DNSSECDetailedValidation(Resource):
             logger.debug(f"Extracted domain for detailed validation: {domain}")
 
             logger.debug(f"Starting detailed DNSSEC analysis for domain: {domain}")
-            validator = DNSSECValidator(domain)
-            result = validator.validate_detailed()
-            attach_idn_forms(result, domain)
+
+            def _run_detailed_validation():
+                validator = DNSSECValidator(domain)
+                res = validator.validate_detailed()
+                attach_idn_forms(res, domain)
+                return res
+
+            result = validate_with_cache(domain, "detailed", _run_detailed_validation)
             logger.info(
-                f"Detailed DNSSEC analysis completed for {domain} with status: {result.get('status', 'unknown')}"
+                f"Detailed DNSSEC analysis completed for {domain} with status: "
+                f"{result.get('status', 'unknown')} (cached={result.get('cached', False)})"
             )
             return result, 200
 
@@ -1424,6 +1679,82 @@ class AnalyticsDomain(Resource):
         except Exception as e:
             logger.error(f"Domain analytics error: {str(e)}", exc_info=True)
             return {"error": "Failed to fetch domain analytics"}, 500
+
+
+# Cache statistics and invalidation endpoints
+@ns_cache.route("/stats")
+class CacheStatsResource(Resource):
+    @ns_cache.doc("get_cache_stats")
+    @ns_cache.response(200, "Success - Cache statistics")
+    @limiter.limit(
+        f"{rate_limits['api_minute']} per minute; {rate_limits['api_hour']} per hour"
+    )
+    def get(self):
+        """
+        Get cache hit/miss statistics.
+
+        Returns counters for cache hits, misses, writes, and skipped entries
+        (results that were not eligible for caching, e.g. errors) along with
+        the current cache configuration. Counters are in-process and reset
+        when the worker restarts.
+        """
+        return cache_stats.as_dict(), 200
+
+
+@ns_cache.route("/invalidate")
+class CacheInvalidateAllResource(Resource):
+    @ns_cache.doc("invalidate_all_cache")
+    @ns_cache.response(200, "Success - Cache cleared")
+    @limiter.limit(
+        f"{rate_limits['api_minute']} per minute; {rate_limits['api_hour']} per hour"
+    )
+    def post(self):
+        """
+        Invalidate the entire validation cache and reset statistics.
+
+        Useful in administration scenarios where the underlying DNS state
+        has changed and operators want to force fresh validations.
+        """
+        try:
+            cache.clear()
+            cache_stats.reset()
+            return {"status": "ok", "message": "Cache cleared"}, 200
+        except Exception as e:
+            logger.error(f"Failed to clear cache: {str(e)}", exc_info=True)
+            return {"status": "error", "message": "Failed to clear cache"}, 500
+
+
+@ns_cache.route("/invalidate/<path:domain>")
+@ns_cache.param("domain", "The domain whose cached entries should be removed")
+class CacheInvalidateDomainResource(Resource):
+    @ns_cache.doc("invalidate_cache_domain")
+    @ns_cache.response(200, "Success - Cached entries removed for domain")
+    @ns_cache.response(400, "Bad Request - Invalid domain format")
+    @limiter.limit(
+        f"{rate_limits['api_minute']} per minute; {rate_limits['api_hour']} per hour"
+    )
+    def post(self, domain):
+        """
+        Invalidate cached validation results for a single domain.
+        """
+        try:
+            from domain_utils import extract_domain_from_input, is_valid_domain_format
+
+            extracted = extract_domain_from_input(domain)
+            if not extracted or not is_valid_domain_format(extracted):
+                return {"status": "error", "message": "Invalid domain"}, 400
+
+            removed = invalidate_cached_domain(extracted)
+            return {
+                "status": "ok",
+                "domain": extracted,
+                "removed_entries": removed,
+            }, 200
+        except Exception as e:
+            logger.error(
+                f"Failed to invalidate cache for {domain}: {str(e)}", exc_info=True
+            )
+            return {"status": "error", "message": "Cache invalidation failed"}, 500
 
 
 # Custom error handlers for rate limiting

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ requests==2.34.0
 python-dateutil==2.9.0.post0
 flask-restx>=1.3.2
 flask-talisman>=1.1.0
+flask-caching==2.3.1
 psutil>=7.2.2
 influxdb-client>=1.50.0
 click>=8.3.3

--- a/tests/unit/test_caching.py
+++ b/tests/unit/test_caching.py
@@ -1,0 +1,405 @@
+"""
+Unit tests for the response caching feature.
+
+Covers:
+- get_cache_config env parsing (enabled/disabled, backend, TTL clamping)
+- _is_cacheable_result skips errors but accepts successful results
+- _extract_min_dns_ttl picks the smallest record TTL
+- validate_with_cache integration: miss -> set -> hit -> "cached" marker
+- /api/cache/stats endpoint exposes hit/miss/set/skip counters
+- /api/cache/invalidate endpoints clear entries
+- Validation endpoint returns the cached result on the second call
+"""
+
+import importlib
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Add app directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../app"))
+
+
+CACHE_ENV_VARS = (
+    "CACHE_ENABLED",
+    "CACHE_BACKEND",
+    "CACHE_DEFAULT_TIMEOUT",
+    "CACHE_RESPECT_DNS_TTL",
+    "CACHE_REDIS_URL",
+)
+
+
+def _clear_cache_env():
+    for var in CACHE_ENV_VARS:
+        os.environ.pop(var, None)
+
+
+def _reload_app():
+    """Reload the app module so environment changes take effect."""
+    import app as app_module  # noqa: F401  (re-imported below)
+
+    importlib.reload(app_module)
+    return app_module
+
+
+class TestCacheConfig(unittest.TestCase):
+    """Tests for ``get_cache_config`` env parsing."""
+
+    def setUp(self):
+        _clear_cache_env()
+
+    def tearDown(self):
+        _clear_cache_env()
+
+    def test_defaults_disabled_null_backend(self):
+        app_module = _reload_app()
+        config, enabled, respect_dns_ttl = app_module.get_cache_config()
+        self.assertFalse(enabled)
+        # When disabled we always fall back to NullCache
+        self.assertEqual(config["CACHE_TYPE"], "NullCache")
+        self.assertEqual(config["CACHE_DEFAULT_TIMEOUT"], 300)
+        self.assertTrue(respect_dns_ttl)
+
+    def test_enabled_simple_backend(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_BACKEND"] = "simple"
+        os.environ["CACHE_DEFAULT_TIMEOUT"] = "600"
+        app_module = _reload_app()
+        config, enabled, _ = app_module.get_cache_config()
+        self.assertTrue(enabled)
+        self.assertEqual(config["CACHE_TYPE"], "SimpleCache")
+        self.assertEqual(config["CACHE_DEFAULT_TIMEOUT"], 600)
+
+    def test_enabled_redis_backend_with_url(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_BACKEND"] = "redis"
+        os.environ["CACHE_REDIS_URL"] = "redis://example:6379/0"
+        app_module = _reload_app()
+        config, enabled, _ = app_module.get_cache_config()
+        self.assertTrue(enabled)
+        self.assertEqual(config["CACHE_TYPE"], "RedisCache")
+        self.assertEqual(config["CACHE_REDIS_URL"], "redis://example:6379/0")
+
+    def test_unknown_backend_falls_back_to_simple(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_BACKEND"] = "memcached-typo"
+        app_module = _reload_app()
+        config, enabled, _ = app_module.get_cache_config()
+        self.assertTrue(enabled)
+        self.assertEqual(config["CACHE_TYPE"], "SimpleCache")
+
+    def test_invalid_timeout_defaults_to_300(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_DEFAULT_TIMEOUT"] = "not-a-number"
+        app_module = _reload_app()
+        config, _, _ = app_module.get_cache_config()
+        self.assertEqual(config["CACHE_DEFAULT_TIMEOUT"], 300)
+
+    def test_respect_dns_ttl_false(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_RESPECT_DNS_TTL"] = "false"
+        app_module = _reload_app()
+        _, _, respect_dns_ttl = app_module.get_cache_config()
+        self.assertFalse(respect_dns_ttl)
+
+
+class TestCacheableResult(unittest.TestCase):
+    """Tests for ``_is_cacheable_result`` filtering."""
+
+    def setUp(self):
+        _clear_cache_env()
+
+    def tearDown(self):
+        _clear_cache_env()
+
+    def test_valid_result_is_cacheable(self):
+        app_module = _reload_app()
+        self.assertTrue(
+            app_module._is_cacheable_result({"status": "valid", "domain": "bondit.dk"})
+        )
+
+    def test_insecure_result_is_cacheable(self):
+        app_module = _reload_app()
+        self.assertTrue(
+            app_module._is_cacheable_result(
+                {"status": "insecure", "domain": "example.com"}
+            )
+        )
+
+    def test_error_status_is_not_cacheable(self):
+        app_module = _reload_app()
+        self.assertFalse(
+            app_module._is_cacheable_result({"status": "error", "errors": ["boom"]})
+        )
+
+    def test_populated_errors_are_not_cacheable(self):
+        app_module = _reload_app()
+        self.assertFalse(
+            app_module._is_cacheable_result(
+                {"status": "valid", "errors": ["non-empty"]}
+            )
+        )
+
+    def test_non_dict_is_not_cacheable(self):
+        app_module = _reload_app()
+        self.assertFalse(app_module._is_cacheable_result(None))
+        self.assertFalse(app_module._is_cacheable_result(["nope"]))
+
+
+class TestMinDNSTTL(unittest.TestCase):
+    """Tests for ``_extract_min_dns_ttl`` and ``_resolve_timeout``."""
+
+    def setUp(self):
+        _clear_cache_env()
+
+    def tearDown(self):
+        _clear_cache_env()
+
+    def test_extracts_smallest_record_ttl(self):
+        app_module = _reload_app()
+        result = {
+            "records": {
+                "dnskey": [{"ttl": 3600}],
+                "ds": [{"ttl": 7200}],
+                "rrsig": [{"original_ttl": 60}],
+            }
+        }
+        self.assertEqual(app_module._extract_min_dns_ttl(result), 60)
+
+    def test_returns_none_when_no_ttl(self):
+        app_module = _reload_app()
+        self.assertIsNone(app_module._extract_min_dns_ttl({"records": {}}))
+
+    def test_resolve_timeout_clamps_to_min_ttl(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_DEFAULT_TIMEOUT"] = "300"
+        os.environ["CACHE_RESPECT_DNS_TTL"] = "true"
+        app_module = _reload_app()
+        result = {"records": {"dnskey": [{"ttl": 30}]}}
+        self.assertEqual(app_module._resolve_timeout(result), 30)
+
+    def test_resolve_timeout_uses_default_when_ttl_larger(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_DEFAULT_TIMEOUT"] = "300"
+        os.environ["CACHE_RESPECT_DNS_TTL"] = "true"
+        app_module = _reload_app()
+        result = {"records": {"dnskey": [{"ttl": 99999}]}}
+        self.assertEqual(app_module._resolve_timeout(result), 300)
+
+    def test_resolve_timeout_ignores_ttl_when_disabled(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_DEFAULT_TIMEOUT"] = "300"
+        os.environ["CACHE_RESPECT_DNS_TTL"] = "false"
+        app_module = _reload_app()
+        result = {"records": {"dnskey": [{"ttl": 30}]}}
+        self.assertEqual(app_module._resolve_timeout(result), 300)
+
+
+class TestValidateWithCache(unittest.TestCase):
+    """End-to-end tests around ``validate_with_cache`` semantics."""
+
+    def setUp(self):
+        _clear_cache_env()
+
+    def tearDown(self):
+        _clear_cache_env()
+
+    def _enabled_app(self):
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_BACKEND"] = "simple"
+        os.environ["CACHE_DEFAULT_TIMEOUT"] = "120"
+        app_module = _reload_app()
+        # Ensure a clean slate for every test.
+        app_module.cache.clear()
+        app_module.cache_stats.reset()
+        return app_module
+
+    def test_disabled_bypasses_cache(self):
+        app_module = _reload_app()  # disabled by default
+
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return {"status": "valid", "domain": "x.com"}
+
+        first = app_module.validate_with_cache("x.com", "basic", fn)
+        second = app_module.validate_with_cache("x.com", "basic", fn)
+        self.assertEqual(len(calls), 2)
+        # No "cached" marker because we never went through the cache.
+        self.assertNotIn("cached", first)
+        self.assertNotIn("cached", second)
+        stats = app_module.cache_stats.as_dict()
+        self.assertEqual(stats["hits"], 0)
+        self.assertEqual(stats["misses"], 0)
+
+    def test_miss_then_hit_marks_cached(self):
+        app_module = self._enabled_app()
+
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return {"status": "valid", "domain": "y.com"}
+
+        first = app_module.validate_with_cache("y.com", "basic", fn)
+        second = app_module.validate_with_cache("y.com", "basic", fn)
+        self.assertEqual(len(calls), 1, "Validator must run only once")
+        self.assertFalse(first.get("cached", False))
+        self.assertTrue(second.get("cached"))
+        stats = app_module.cache_stats.as_dict()
+        self.assertEqual(stats["hits"], 1)
+        self.assertEqual(stats["misses"], 1)
+        self.assertEqual(stats["sets"], 1)
+        self.assertEqual(stats["skipped"], 0)
+
+    def test_error_results_not_cached(self):
+        app_module = self._enabled_app()
+
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return {"status": "error", "errors": ["boom"]}
+
+        app_module.validate_with_cache("z.com", "basic", fn)
+        app_module.validate_with_cache("z.com", "basic", fn)
+        self.assertEqual(len(calls), 2)
+        stats = app_module.cache_stats.as_dict()
+        self.assertEqual(stats["sets"], 0)
+        self.assertEqual(stats["skipped"], 2)
+
+    def test_basic_and_detailed_use_separate_keys(self):
+        app_module = self._enabled_app()
+
+        def basic():
+            return {"status": "valid", "kind": "basic"}
+
+        def detailed():
+            return {"status": "valid", "kind": "detailed"}
+
+        b1 = app_module.validate_with_cache("k.com", "basic", basic)
+        d1 = app_module.validate_with_cache("k.com", "detailed", detailed)
+        self.assertEqual(b1["kind"], "basic")
+        self.assertEqual(d1["kind"], "detailed")
+
+        # Cache should now return them separately.
+        b2 = app_module.validate_with_cache(
+            "k.com", "basic", lambda: {"status": "valid", "kind": "WRONG"}
+        )
+        d2 = app_module.validate_with_cache(
+            "k.com", "detailed", lambda: {"status": "valid", "kind": "WRONG"}
+        )
+        self.assertEqual(b2["kind"], "basic")
+        self.assertEqual(d2["kind"], "detailed")
+
+    def test_invalidate_domain_removes_entries(self):
+        app_module = self._enabled_app()
+
+        def fn():
+            return {"status": "valid", "domain": "foo.test"}
+
+        app_module.validate_with_cache("foo.test", "basic", fn)
+        app_module.validate_with_cache("foo.test", "detailed", fn)
+        removed = app_module.invalidate_cached_domain("foo.test")
+        self.assertGreaterEqual(removed, 1)
+
+        calls = []
+
+        def fn2():
+            calls.append(1)
+            return {"status": "valid", "domain": "foo.test"}
+
+        app_module.validate_with_cache("foo.test", "basic", fn2)
+        self.assertEqual(len(calls), 1, "Cache entry should have been invalidated")
+
+
+class TestCacheHTTPEndpoints(unittest.TestCase):
+    """HTTP tests for the cache namespace and validate-endpoint integration."""
+
+    def setUp(self):
+        _clear_cache_env()
+        os.environ["CACHE_ENABLED"] = "true"
+        os.environ["CACHE_BACKEND"] = "simple"
+        os.environ["CACHE_DEFAULT_TIMEOUT"] = "120"
+        # Disable rate limiting to avoid flakiness when running many requests.
+        os.environ["RATE_LIMIT_API_MINUTE"] = "10000"
+        os.environ["RATE_LIMIT_API_HOUR"] = "10000"
+        self.app_module = _reload_app()
+        self.app_module.cache.clear()
+        self.app_module.cache_stats.reset()
+        self.client = self.app_module.app.test_client()
+
+    def tearDown(self):
+        _clear_cache_env()
+        os.environ.pop("RATE_LIMIT_API_MINUTE", None)
+        os.environ.pop("RATE_LIMIT_API_HOUR", None)
+
+    def test_stats_endpoint_initial_state(self):
+        response = self.client.get("/api/cache/stats")
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertTrue(data["enabled"])
+        self.assertEqual(data["backend"], "SimpleCache")
+        self.assertEqual(data["hits"], 0)
+        self.assertEqual(data["misses"], 0)
+
+    @patch("dnssec_validator.DNSSECValidator.validate")
+    def test_validate_endpoint_returns_cached_result(self, mock_validate):
+        mock_validate.return_value = {
+            "domain": "bondit.dk",
+            "status": "valid",
+            "records": {"dnskey": [{"ttl": 3600}]},
+        }
+
+        # First call: miss
+        r1 = self.client.get("/api/validate/bondit.dk")
+        self.assertEqual(r1.status_code, 200)
+        # Second call: hit
+        r2 = self.client.get("/api/validate/bondit.dk")
+        self.assertEqual(r2.status_code, 200)
+
+        # Validator should have been called once.
+        self.assertEqual(mock_validate.call_count, 1)
+
+        # Second response is marked as cached.
+        self.assertTrue(r2.get_json().get("cached", False))
+
+        stats = self.client.get("/api/cache/stats").get_json()
+        self.assertEqual(stats["hits"], 1)
+        self.assertEqual(stats["misses"], 1)
+
+    @patch("dnssec_validator.DNSSECValidator.validate")
+    def test_invalidate_domain_endpoint(self, mock_validate):
+        mock_validate.return_value = {"domain": "bondit.dk", "status": "valid"}
+
+        self.client.get("/api/validate/bondit.dk")
+        # Invalidate
+        inv = self.client.post("/api/cache/invalidate/bondit.dk")
+        self.assertEqual(inv.status_code, 200)
+        # Second validate should miss again -> validator called twice total.
+        self.client.get("/api/validate/bondit.dk")
+        self.assertEqual(mock_validate.call_count, 2)
+
+    @patch("dnssec_validator.DNSSECValidator.validate")
+    def test_invalidate_all_endpoint(self, mock_validate):
+        mock_validate.return_value = {"domain": "bondit.dk", "status": "valid"}
+
+        self.client.get("/api/validate/bondit.dk")
+        clear = self.client.post("/api/cache/invalidate")
+        self.assertEqual(clear.status_code, 200)
+        stats = self.client.get("/api/cache/stats").get_json()
+        self.assertEqual(stats["hits"], 0)
+        self.assertEqual(stats["misses"], 0)
+        # Next validate must hit the validator again.
+        self.client.get("/api/validate/bondit.dk")
+        self.assertEqual(mock_validate.call_count, 2)
+
+    def test_invalidate_domain_endpoint_rejects_bad_input(self):
+        response = self.client.post("/api/cache/invalidate/!!!not-a-domain!!!")
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Opt-in caching of DNSSEC validation results via Flask-Caching (added to `requirements.txt`).
- `CACHE_ENABLED` (default `false`) gates the feature.
- `CACHE_BACKEND` chooses between `simple` (in-memory) or `redis` — Redis backend is supported but requires the `redis` package to be installed externally; missing-backend gracefully falls back to NullCache.
- `CACHE_RESPECT_DNS_TTL` clamps the effective TTL to the smallest record TTL observed in the result, so cached entries can't outlive their source records.
- New `/api/cache/stats` (hits/misses/sets/skipped + backend identifier) and `/api/cache/invalidate[/<domain>]` endpoints.
- Error results (`status: "error"` or non-empty `errors`) are never cached.

Closes #36.

## Test plan
- [x] 26 new tests in `tests/unit/test_caching.py` (config parsing, cacheability filter, TTL clamping, miss→hit semantics, separate keys for basic vs detailed, HTTP endpoints with mocked validator)
- [x] Full suite: 201 passing
- [x] black formatted, pylint 9.98/10
- [ ] Manual: set `CACHE_ENABLED=true`, validate a domain twice, confirm second response has `"cached": true` and `/api/cache/stats` reports a hit