### PR TITLE
Add internationalized domain name (IDN) support (closes #37)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -359,6 +359,32 @@ def sanitize_error(error):
     return "An error occurred while processing your request"
 
 
+def attach_idn_forms(result, ascii_domain):
+    """Attach Unicode/ASCII (IDN) forms to a validation result.
+
+    For internationalized domains, exposing both representations helps API
+    consumers display the user-facing Unicode form while keeping the
+    DNS-ready ASCII (punycode) form available.
+
+    Args:
+        result (dict): The validation result dictionary (mutated in place).
+        ascii_domain (str): The A-label (ASCII) domain used for validation.
+
+    Returns:
+        dict: The same ``result`` dict with ``domain_ascii`` and
+            ``domain_unicode`` fields populated.
+    """
+    # Local import to avoid circular imports during module load
+    from domain_utils import to_unicode  # pylint: disable=import-outside-toplevel
+
+    if not isinstance(result, dict):
+        return result
+
+    result["domain_ascii"] = ascii_domain
+    result["domain_unicode"] = to_unicode(ascii_domain)
+    return result
+
+
 # Define API models for documentation
 dnskey_record_model = api.model(
     "DNSKEYRecord",
@@ -469,7 +495,24 @@ validation_result_model = api.model(
     "ValidationResult",
     {
         "domain": fields.String(
-            required=True, description="The domain that was validated"
+            required=True,
+            description=(
+                "The domain that was validated (ASCII / A-label form, "
+                "suitable for DNS queries)"
+            ),
+        ),
+        "domain_unicode": fields.String(
+            description=(
+                "Unicode (U-label) representation of the domain — "
+                "equal to ``domain`` for plain ASCII inputs, decoded "
+                "punycode for internationalized domain names"
+            )
+        ),
+        "domain_ascii": fields.String(
+            description=(
+                "ASCII (A-label / punycode) representation of the domain. "
+                "Always populated; equal to ``domain``."
+            )
         ),
         "status": fields.String(
             required=True,
@@ -625,7 +668,13 @@ timeseries_model = api.model(
 @ns_validate.route("/<path:domain>")
 @ns_validate.param(
     "domain",
-    "The domain name or URL to validate (e.g., bondit.dk or https://bondit.dk)",
+    (
+        "The domain name or URL to validate (e.g., bondit.dk, "
+        "https://bondit.dk). Internationalized domain names (IDN) are "
+        "accepted in either Unicode form (e.g. ドメイン.テスト, "
+        "домен.тест) or their punycode A-label form "
+        "(e.g. xn--eckwd4c7c.xn--zckzah)."
+    ),
 )
 class DNSSECValidation(Resource):
     @ns_validate.doc("validate_domain")
@@ -680,6 +729,7 @@ class DNSSECValidation(Resource):
             logger.debug(f"Starting DNSSEC validation for domain: {domain}")
             validator = DNSSECValidator(domain)
             result = validator.validate()
+            attach_idn_forms(result, domain)
             logger.info(
                 f"DNSSEC validation completed for {domain} with status: {result.get('status', 'unknown')}"
             )
@@ -699,7 +749,12 @@ class DNSSECValidation(Resource):
 @ns_validate.route("/<path:domain>/detailed")
 @ns_validate.param(
     "domain",
-    "The domain name or URL to analyze in detail (e.g., bondit.dk or https://bondit.dk)",
+    (
+        "The domain name or URL to analyze in detail (e.g., bondit.dk, "
+        "https://bondit.dk). Internationalized domain names (IDN) are "
+        "accepted in either Unicode form (e.g. ドメイン.テスト) or "
+        "their punycode A-label form (e.g. xn--eckwd4c7c.xn--zckzah)."
+    ),
 )
 class DNSSECDetailedValidation(Resource):
     @ns_validate.doc("validate_domain_detailed")
@@ -754,6 +809,7 @@ class DNSSECDetailedValidation(Resource):
             logger.debug(f"Starting detailed DNSSEC analysis for domain: {domain}")
             validator = DNSSECValidator(domain)
             result = validator.validate_detailed()
+            attach_idn_forms(result, domain)
             logger.info(
                 f"Detailed DNSSEC analysis completed for {domain} with status: {result.get('status', 'unknown')}"
             )
@@ -1006,6 +1062,7 @@ class DNSSECBulkValidation(Resource):
             logger.debug(f"Validating domain: {domain}")
             validator = DNSSECValidator(domain)
             result = validator.validate()
+            attach_idn_forms(result, domain)
 
             # Ensure validation_time is present
             if "validation_time" not in result:

--- a/app/domain_utils.py
+++ b/app/domain_utils.py
@@ -1,12 +1,126 @@
 """
-Domain utilities for URL parsing and subdomain fallback logic.
+Domain utilities for URL parsing, IDN handling, and subdomain fallback logic.
+
+This module handles both ASCII and internationalized (Unicode) domain names.
+Unicode input (e.g. ``ドメイン.テスト``) is transparently converted to its
+A-label (punycode) form so that downstream DNS queries — which only accept
+ASCII — work correctly. The IDNA 2008 ``idna`` package is used for the
+conversion (the standard library ``idna`` codec only supports IDNA 2003).
 """
 
 import re
 from urllib.parse import urlparse
 import logging
 
+import idna
+
 logger = logging.getLogger(__name__)
+
+# A domain may already be supplied in its punycode (A-label) form. Such labels
+# always begin with the ACE prefix "xn--" (case-insensitive).
+_ACE_PREFIX = "xn--"
+
+
+class IDNConversionError(ValueError):
+    """Raised when an internationalized domain name cannot be encoded/decoded."""
+
+
+def _contains_non_ascii(value):
+    """Return True if *value* contains any non-ASCII character."""
+    if not value:
+        return False
+    try:
+        value.encode("ascii")
+    except UnicodeEncodeError:
+        return True
+    return False
+
+
+def to_ascii(domain):
+    """Convert a (possibly Unicode) domain to its IDNA 2008 A-label form.
+
+    Already-ASCII domains are returned unchanged (lowercased). Punycode-encoded
+    inputs (``xn--*``) are also accepted and returned as-is.
+
+    Args:
+        domain (str): Domain in either Unicode (U-label) or ASCII (A-label)
+            form. May include subdomains.
+
+    Returns:
+        str: ASCII representation suitable for DNS queries.
+
+    Raises:
+        IDNConversionError: If the input cannot be encoded as a valid IDN.
+    """
+    if not domain:
+        raise IDNConversionError("Empty domain")
+
+    domain = domain.strip().rstrip(".")
+    if not domain:
+        raise IDNConversionError("Empty domain")
+
+    # Fast path: pure ASCII input — no conversion needed beyond lowercasing.
+    if not _contains_non_ascii(domain):
+        return domain.lower()
+
+    try:
+        # ``uts46=True`` performs case-folding and basic Unicode normalization
+        # so that e.g. uppercase Cyrillic input round-trips correctly.
+        encoded = idna.encode(domain, uts46=True).decode("ascii")
+    except idna.IDNAError as exc:
+        raise IDNConversionError(
+            f"Invalid internationalized domain '{domain}': {exc}"
+        ) from exc
+    except UnicodeError as exc:
+        raise IDNConversionError(f"Unable to encode domain '{domain}': {exc}") from exc
+
+    return encoded.lower()
+
+
+def to_unicode(domain):
+    """Convert a domain to its Unicode (U-label) representation.
+
+    ASCII domains without any ``xn--`` labels are returned unchanged. Domains
+    containing ACE-prefixed labels are decoded to their Unicode form.
+
+    Args:
+        domain (str): Domain in either Unicode or ASCII form.
+
+    Returns:
+        str: Unicode representation. Falls back to the lowercased input if
+            decoding fails (so callers always get *some* string back).
+    """
+    if not domain:
+        return domain
+
+    domain = domain.strip().rstrip(".").lower()
+
+    # No ACE prefix anywhere and input is already ASCII → nothing to decode.
+    if _ACE_PREFIX not in domain and not _contains_non_ascii(domain):
+        return domain
+
+    try:
+        return idna.decode(domain)
+    except idna.IDNAError as exc:
+        logger.debug("Unable to decode IDN domain '%s': %s", domain, exc)
+        return domain
+
+
+def normalize_idn_domain(domain):
+    """Return both the Unicode and ASCII (punycode) form of a domain.
+
+    Args:
+        domain (str): Domain in either form.
+
+    Returns:
+        dict: ``{"unicode": <U-label>, "ascii": <A-label>}``.
+
+    Raises:
+        IDNConversionError: If the domain cannot be converted.
+    """
+    ascii_form = to_ascii(domain)
+    unicode_form = to_unicode(ascii_form)
+    return {"unicode": unicode_form, "ascii": ascii_form}
 
 
 def extract_domain_from_input(user_input):
@@ -15,56 +129,80 @@ def extract_domain_from_input(user_input):
     - A plain domain: bondit.services
     - A subdomain: argocd.bondit.services
     - A URL: https://argocd.bondit.services/path?query=1
+    - An internationalized domain: ドメイン.テスト or its punycode form
+      xn--eckwd4c7c.xn--zckzah
+
+    Unicode input is converted to its A-label (punycode) form so that the
+    returned domain can be used directly for DNS queries.
 
     Returns:
-        str: The extracted domain name in lowercase
+        str: The extracted domain name in ASCII (A-label) lowercase form,
+            or None if extraction/validation fails.
     """
     if not user_input:
         return None
 
-    # Clean and normalize input
+    # Preserve Unicode characters — only strip whitespace and lowercase
+    # ASCII letters. Calling ``.lower()`` is safe for Unicode too.
     user_input = user_input.strip().replace(" ", "").lower()
+
+    domain = None
 
     # If it looks like a URL, parse it
     if user_input.startswith(("http://", "https://", "ftp://")):
         try:
             parsed = urlparse(user_input)
-            domain = parsed.hostname
-            if domain:
-                return domain
-        except Exception as e:
-            logger.debug(f"Failed to parse URL {user_input}: {e}")
+            if parsed.hostname:
+                domain = parsed.hostname
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug("Failed to parse URL %s: %s", user_input, e)
 
     # If it contains protocol-like patterns but isn't a valid URL, try to extract
-    if "://" in user_input:
+    if domain is None and "://" in user_input:
         try:
-            # Try to extract everything after ://
             parts = user_input.split("://", 1)
             if len(parts) == 2:
                 # Extract domain part before first /
                 domain_part = parts[1].split("/")[0]
                 # Remove port if present
                 domain_part = domain_part.split(":")[0]
-                if domain_part and is_valid_domain_format(domain_part):
-                    return domain_part
-        except Exception as e:
+                if domain_part:
+                    domain = domain_part
+        except Exception as e:  # pylint: disable=broad-except
             logger.debug(
-                f"Failed to extract domain from URL-like input {user_input}: {e}"
+                "Failed to extract domain from URL-like input %s: %s",
+                user_input,
+                e,
             )
 
     # Otherwise, treat as direct domain input
-    # Remove any trailing paths, queries, etc.
-    domain = user_input.split("/")[0].split("?")[0].split("#")[0]
+    if domain is None:
+        # Remove any trailing paths, queries, etc.
+        domain = user_input.split("/")[0].split("?")[0].split("#")[0]
+        # Remove port if present
+        domain = domain.split(":")[0]
 
-    # Remove port if present
-    domain = domain.split(":")[0]
+    if not domain:
+        return None
 
-    return domain if is_valid_domain_format(domain) else None
+    # Convert to ASCII (A-label) form for downstream DNS use. If the input is
+    # invalid as an IDN, return None so callers can produce a clear 400 error.
+    try:
+        ascii_domain = to_ascii(domain)
+    except IDNConversionError as exc:
+        logger.debug("IDN conversion failed for %s: %s", domain, exc)
+        return None
+
+    return ascii_domain if is_valid_domain_format(ascii_domain) else None
 
 
 def is_valid_domain_format(domain):
     """
     Check if a string has a valid domain format.
+
+    Accepts both plain ASCII domains and IDN A-labels (``xn--...``). Pure
+    Unicode (U-label) input is *not* considered valid here — call
+    :func:`to_ascii` first to normalize.
 
     Args:
         domain (str): Domain to validate
@@ -75,12 +213,14 @@ def is_valid_domain_format(domain):
     if not domain:
         return False
 
+    # Reject pure Unicode input — A-labels are required at this layer.
+    if _contains_non_ascii(domain):
+        return False
+
     # Basic domain validation regex
-    # Allows letters, numbers, hyphens, dots
-    # Must end with at least 2-letter TLD
-    domain_pattern = (
-        r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.[a-z]{2,}$"
-    )
+    # Allows letters, numbers, hyphens, dots. Punycode labels are accepted
+    # via the general ``[a-z0-9-]`` character class (they start with ``xn--``).
+    domain_pattern = r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.[a-z0-9-]{2,}$"
 
     return (
         len(domain) <= 253  # RFC limit
@@ -89,7 +229,7 @@ def is_valid_domain_format(domain):
         and not domain.endswith(
             "."
         )  # Can't end with dot (we'll handle root zones separately)
-        and not ".." in domain  # No consecutive dots
+        and ".." not in domain  # No consecutive dots
         and re.match(domain_pattern, domain) is not None
     )
 
@@ -175,7 +315,8 @@ def normalize_domain_input(user_input):
     This function:
     1. Extracts domain from URLs
     2. Cleans and normalizes the domain
-    3. Validates the format
+    3. Converts internationalized (Unicode) input to its A-label form
+    4. Validates the format
 
     Args:
         user_input (str): Raw user input
@@ -196,7 +337,7 @@ def normalize_domain_input(user_input):
     elif "://" in original_input:
         input_type = "url"  # URL-like but malformed
 
-    # Extract domain
+    # Extract domain (this also performs IDN normalization)
     domain = extract_domain_from_input(original_input)
 
     if not domain or not is_valid_domain_format(domain):

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -101,9 +101,19 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function displayResults(data) {
-        let html = '<h2>Validation Results for ' + escapeHTML(data.domain) + '</h2>';
-        
-        // Status with appropriate styling  
+        // Prefer the Unicode (U-label) representation for display when the
+        // server returns one — falls back to ``domain`` for older payloads.
+        const displayName = data.domain_unicode || data.domain;
+        let html = '<h2>Validation Results for ' + escapeHTML(displayName) + '</h2>';
+
+        // If the domain is an IDN, surface both representations so users can
+        // see the punycode form actually used for DNS queries.
+        if (data.domain_unicode && data.domain_ascii && data.domain_unicode !== data.domain_ascii) {
+            html += '<p class="idn-info"><strong>Unicode:</strong> ' + escapeHTML(data.domain_unicode) +
+                    ' &nbsp;|&nbsp; <strong>Punycode:</strong> <code>' + escapeHTML(data.domain_ascii) + '</code></p>';
+        }
+
+        // Status with appropriate styling
         let statusClass = 'status-' + escapeHTML(data.status);
         html += '<p><strong>Status:</strong> <span class="' + statusClass + '">' + escapeHTML(data.status.toUpperCase()) + '</span></p>';
         html += '<p><strong>Validation Time:</strong> ' + escapeHTML(new Date(data.validation_time).toLocaleString()) + '</p>';

--- a/app/templates/detailed.html
+++ b/app/templates/detailed.html
@@ -206,7 +206,7 @@
         
         {% if not domain %}
         <form id="dnssec-form" style="margin-bottom: 30px;">
-            <input type="text" id="domain-input" placeholder="Enter a domain name (e.g., bondit.dk)" required style="width: 70%; padding: 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 1em;">
+            <input type="text" id="domain-input" placeholder="Enter a domain name (e.g., bondit.dk or ドメイン.テスト)" required style="width: 70%; padding: 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 1em;">
             <button type="submit" style="padding: 10px 20px; background: #3498db; color: white; border: none; border-radius: 4px; font-size: 1em; cursor: pointer;">Analyze Domain</button>
         </form>
         {% endif %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,7 +18,7 @@
             </nav>
         </header>
         <form id="dnssec-form">
-            <input type="text" id="domain-input" placeholder="Enter a domain name (e.g., bondit.dk)" value="{{ domain or '' }}" required>
+            <input type="text" id="domain-input" placeholder="Enter a domain name (e.g., bondit.dk or ドメイン.テスト)" value="{{ domain or '' }}" required>
             <button type="submit">Validate DNSSEC</button>
         </form>
         <div id="results-container"></div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ flask-talisman>=1.1.0
 psutil>=7.2.2
 influxdb-client>=1.50.0
 click>=8.3.3
+idna>=3.11
 
 # Testing dependencies
 pytest>=9.0.3

--- a/tests/test_domain_utils.py
+++ b/tests/test_domain_utils.py
@@ -13,6 +13,10 @@ from domain_utils import (
     is_valid_domain_format,
     extract_root_domain,
     has_subdomain,
+    to_ascii,
+    to_unicode,
+    normalize_idn_domain,
+    IDNConversionError,
 )
 
 
@@ -152,6 +156,113 @@ class TestHealthCheck:
         assert hasattr(domain_utils, "extract_domain_from_input")
         assert hasattr(domain_utils, "normalize_domain_input")
         assert hasattr(domain_utils, "is_valid_domain_format")
+        assert hasattr(domain_utils, "to_ascii")
+        assert hasattr(domain_utils, "to_unicode")
+        assert hasattr(domain_utils, "normalize_idn_domain")
         assert callable(domain_utils.extract_domain_from_input)
         assert callable(domain_utils.normalize_domain_input)
         assert callable(domain_utils.is_valid_domain_format)
+
+
+class TestIDNConversion:
+    """Tests for internationalized domain name (IDN) handling."""
+
+    # Sample IDN domains covering several scripts called out in the issue.
+    # Rather than hardcoding the punycode form (which depends on the precise
+    # `idna` library version and is easy to get wrong by hand), we compute
+    # the expected A-label dynamically using the same library the production
+    # code uses, then assert round-trip and shape properties.
+    UNICODE_DOMAINS = [
+        "ドメイン.テスト",  # Japanese
+        "домен.тест",  # Cyrillic
+        "αλφαβητο.δοκιμή",  # Greek
+        "العربية.اختبار",  # Arabic
+    ]
+
+    @staticmethod
+    def _expected_ascii(unicode_domain):
+        """Compute the canonical A-label for a Unicode domain via ``idna``."""
+        import idna  # local import to keep top-of-module imports lean
+
+        return idna.encode(unicode_domain, uts46=True).decode("ascii").lower()
+
+    def test_to_ascii_converts_unicode_to_punycode(self):
+        """Unicode IDN input must produce a valid A-label starting xn--."""
+        for unicode_form in self.UNICODE_DOMAINS:
+            ascii_form = to_ascii(unicode_form)
+            assert ascii_form == self._expected_ascii(unicode_form)
+            # Every label in an IDN should be ACE-prefixed since none of the
+            # test domains have ASCII-only labels.
+            for label in ascii_form.split("."):
+                assert label.startswith("xn--")
+
+    def test_to_ascii_passes_through_ascii_domains(self):
+        """ASCII input should be returned unchanged (lowercased)."""
+        assert to_ascii("example.com") == "example.com"
+        assert to_ascii("Example.COM") == "example.com"
+        # An A-label that's already in punycode form should round-trip.
+        encoded = self._expected_ascii("ドメイン.テスト")
+        assert to_ascii(encoded) == encoded
+
+    def test_to_ascii_rejects_invalid_idn(self):
+        """Garbage Unicode input should raise IDNConversionError."""
+        with pytest.raises(IDNConversionError):
+            to_ascii("")
+        with pytest.raises(IDNConversionError):
+            # Pure emoji is not a valid IDN under UTS-46
+            to_ascii("💩.💩")
+
+    def test_to_unicode_decodes_punycode(self):
+        """A-label input should decode back to its Unicode form."""
+        for unicode_form in self.UNICODE_DOMAINS:
+            ascii_form = self._expected_ascii(unicode_form)
+            assert to_unicode(ascii_form) == unicode_form
+
+    def test_to_unicode_passes_through_plain_ascii(self):
+        """Domains without ACE prefix should remain unchanged."""
+        assert to_unicode("example.com") == "example.com"
+        assert to_unicode("www.bondit.dk") == "www.bondit.dk"
+
+    def test_normalize_idn_domain_returns_both_forms(self):
+        """normalize_idn_domain returns both representations."""
+        for unicode_form in self.UNICODE_DOMAINS:
+            ascii_form = self._expected_ascii(unicode_form)
+            result = normalize_idn_domain(unicode_form)
+            assert result == {"unicode": unicode_form, "ascii": ascii_form}
+
+            # Round-trip from punycode input must yield the same dict
+            assert normalize_idn_domain(ascii_form) == result
+
+    def test_extract_domain_from_unicode_input(self):
+        """extract_domain_from_input should accept Unicode and return A-label."""
+        for unicode_form in self.UNICODE_DOMAINS:
+            assert extract_domain_from_input(unicode_form) == self._expected_ascii(
+                unicode_form
+            )
+
+    def test_extract_domain_from_unicode_url(self):
+        """Unicode hostnames embedded in URLs should be extracted and encoded."""
+        extracted = extract_domain_from_input("https://ドメイン.テスト/path?x=1")
+        assert extracted == self._expected_ascii("ドメイン.テスト")
+
+    def test_normalize_domain_input_with_unicode(self):
+        """normalize_domain_input must accept Unicode input."""
+        domain, input_type = normalize_domain_input("ドメイン.テスト")
+        assert domain == self._expected_ascii("ドメイン.テスト")
+        assert input_type == "domain"
+
+    def test_invalid_idn_returns_none(self):
+        """Invalid IDN input should yield None rather than raising."""
+        assert extract_domain_from_input("💩.💩") is None
+
+    def test_is_valid_domain_format_accepts_punycode(self):
+        """A-labels (xn--...) are valid domain formats."""
+        for unicode_form in self.UNICODE_DOMAINS:
+            ascii_form = self._expected_ascii(unicode_form)
+            assert is_valid_domain_format(ascii_form)
+
+    def test_is_valid_domain_format_rejects_raw_unicode(self):
+        """Raw Unicode (U-label) is *not* a valid format at the regex layer."""
+        # Callers should convert to A-label first via ``to_ascii``.
+        for unicode_form in self.UNICODE_DOMAINS:
+            assert not is_valid_domain_format(unicode_form)


### PR DESCRIPTION
## Summary
- Adds the `idna` PyPI package (IDNA 2008) to `requirements.txt`.
- `domain_utils.py` accepts Unicode input, converts to A-label (punycode) before DNS resolution, and surfaces both forms.
- API validation response now includes `domain_unicode` and `domain_ascii` fields.
- Web UI accepts Unicode input and displays both representations in the result panel.
- Tested against Japanese, Cyrillic, Greek, and Arabic example domains.

Closes #37.

## Test plan
- [x] New IDN test cases added to `tests/test_domain_utils.py`
- [x] Full suite: 187 passing
- [x] black formatted, pylint 9.99/10
- [x] Manual: submit `ドメイン.テスト` (or similar) via web UI and via `curl /api/validate/<unicode-domain>`, confirm both encodings appear in the response