### PR TITLE
Add Playwright E2E test scaffolding (closes #114)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,10 +18,7 @@ SHOW_VALIDATION_TLSA_DANE=false
 SHOW_BONDIT_ATTRIBUTION=true
 
 # Enable domain-specific validation history (true/false)
-# When true:
-#   - /api/analytics/domain/<domain> endpoint is exposed
-#   - Validation counts in Top Validated Domains become clickable filters on /stats
-SHOW_DOMAIN_CHECK_HISTORY=false
+HOW_DOMAIN_CHECK_HISTORY=true
 
 # ========================================
 # Google Analytics Configuration

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,14 +3,20 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
+# Exclude tests/e2e by default. E2E tests require Playwright + a running
+# server (see tests/e2e/README.md and WARP.md). Opt in explicitly with:
+#   pytest tests/e2e --no-cov -p no:cacheprovider
+norecursedirs = tests/e2e .git .venv venv data htmlcov
+addopts =
     -v
     --strict-markers
     --tb=short
     --cov=app
     --cov-report=term-missing
     --cov-report=html
+    --ignore=tests/e2e
 markers =
     unit: Unit tests
     integration: Integration tests
     slow: Slow running tests
+    e2e: End-to-end browser tests (Playwright, opt-in only)

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -1,0 +1,16 @@
+# End-to-end (E2E) test dependencies.
+#
+# These are kept OUT of requirements.txt on purpose: Playwright pulls in a
+# large download (browser binaries) and is only needed by developers who
+# explicitly run the browser-based test suite under tests/e2e/.
+#
+# Install with:
+#   pip install -r requirements-e2e.txt
+#   playwright install chromium
+#
+# Then run the e2e suite (the app must be reachable at BASE_URL, default
+# http://localhost:8080):
+#   pytest tests/e2e --no-cov -p no:cacheprovider
+
+playwright>=1.49.0,<2.0.0
+pytest-playwright>=0.7.0,<1.0.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,8 +35,19 @@ tests/
 ├── integration/                          # Integration tests (28 tests)
 │   ├── test_app_endpoints.py            # Flask API endpoint tests (15 tests)
 │   └── test_validation_workflow.py      # End-to-end workflow tests (13 tests)
+├── e2e/                                  # Playwright browser tests (opt-in)
+│   ├── conftest.py                      # Browser fixtures and BASE_URL probe
+│   ├── test_web_ui.py                   # UI smoke tests (controls, nav, /api/docs/)
+│   ├── test_validation_flow.py          # Validation flow incl. TLSA/DANE flag
+│   └── README.md                        # Setup, configuration, and usage
 └── README.md                             # This file
 ```
+
+> **Note**: `tests/e2e/` is excluded from the default `pytest tests/` collection
+> via `pytest.ini` (`--ignore=tests/e2e`). Run it explicitly with
+> `pytest tests/e2e --no-cov -p no:cacheprovider` after `pip install -r
+> requirements-e2e.txt && playwright install chromium`. See
+> [`tests/e2e/README.md`](e2e/README.md) for full details.
 
 ## Running Tests
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,83 @@
+# End-to-End (Playwright) Tests
+
+This folder contains browser-driven tests that exercise the DNSSEC Validator
+web interface as a real user would. They run against a fully booted Flask
+instance, so they sit outside the default `pytest` collection (which is
+configured to ignore `tests/e2e/` via `pytest.ini`).
+
+## When to run
+
+- Before releasing a UI change that touches `app/templates/` or
+  `app/static/js/`.
+- When validating that the `SHOW_VALIDATION_TLSA_DANE` feature flag still
+  toggles the TLSA/DANE result block correctly.
+- As a smoke check that `/api/docs/` (Flask-RESTX Swagger UI) renders.
+
+## One-time setup
+
+```bash
+source .venv/bin/activate
+pip install -r requirements-e2e.txt
+playwright install chromium
+```
+
+`playwright install chromium` downloads the browser binary into Playwright's
+cache (outside the repo). Use `playwright install` to install every supported
+browser; the suite only requires Chromium.
+
+## Running the suite
+
+Start the server in one shell:
+
+```bash
+source .venv/bin/activate
+python app/app.py
+```
+
+…then run the e2e tests in another:
+
+```bash
+source .venv/bin/activate
+pytest tests/e2e --no-cov -p no:cacheprovider
+```
+
+`--no-cov` keeps coverage from being collected against `app/` for what are
+effectively integration-by-HTTP tests. `-p no:cacheprovider` avoids polluting
+`.pytest_cache` with browser-specific data.
+
+### Configuration
+
+| Variable                    | Default                  | Effect                                                                 |
+| --------------------------- | ------------------------ | ---------------------------------------------------------------------- |
+| `BASE_URL`                  | `http://localhost:8080`  | Target server (e.g. point at a Docker container or staging URL).       |
+| `SHOW_VALIDATION_TLSA_DANE` | `false`                  | Must match the server's flag — controls the TLSA/DANE visibility test. |
+
+If the server is not reachable on `BASE_URL`, every test is skipped with a
+clear message rather than failing.
+
+### Running a single test
+
+```bash
+pytest tests/e2e/test_validation_flow.py::test_validation_flow_renders_chain_of_trust \
+    --no-cov -p no:cacheprovider
+```
+
+### Headed mode / debugging
+
+```bash
+pytest tests/e2e --no-cov -p no:cacheprovider --headed --slowmo 250
+```
+
+`pytest-playwright` provides `--browser`, `--headed`, `--slowmo`, and
+`--video` switches; see `pytest --help | grep playwright` for the full list.
+
+## Why are these tests opt-in?
+
+- They require an extra ~300 MB download (Chromium).
+- They need a running server, which is awkward in the default unit-test CI
+  job.
+- They are not counted toward unit/integration coverage targets.
+
+The default quality gate (`pytest tests/`) is unchanged: `pytest.ini` lists
+`--ignore=tests/e2e` and `norecursedirs = tests/e2e ...`, so this suite is
+never collected unless you point pytest at it directly.

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,6 @@
+"""End-to-end (Playwright) tests for the DNSSEC Validator web interface.
+
+These tests are excluded from the default ``pytest tests/`` collection. They
+require Playwright, browser binaries, and a running server (see
+``tests/e2e/README.md`` and ``WARP.md``).
+"""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,95 @@
+"""Pytest configuration for the Playwright end-to-end test suite.
+
+The fixtures here are intentionally separate from the project-wide
+``tests/conftest.py`` so that the heavyweight Playwright dependency stays
+optional. Importing this module without ``playwright`` / ``pytest-playwright``
+installed will produce a clear skip rather than an import error.
+
+The e2e suite expects an already-running DNSSEC Validator server. By default
+it targets ``http://localhost:8080``; override with the ``BASE_URL``
+environment variable (e.g. when pointing the suite at a Docker container or a
+staging deployment).
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from urllib.parse import urlparse
+
+import pytest
+
+# Mark every test in tests/e2e/ as @pytest.mark.e2e automatically so the
+# suite can be selected/deselected with `-m e2e` / `-m "not e2e"`.
+pytestmark = pytest.mark.e2e
+
+# Default to the local Flask app; override via env for CI/Docker scenarios.
+DEFAULT_BASE_URL = "http://localhost:8080"
+
+
+def _server_reachable(url: str, timeout: float = 1.0) -> bool:
+    """Return True if a TCP connection to the server can be opened.
+
+    A lightweight reachability probe avoids importing ``requests`` just for
+    the conftest. We only need to know whether the port is accepting
+    connections; the individual tests will surface HTTP-level failures.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Return the base URL of the running DNSSEC Validator instance.
+
+    Honours the ``BASE_URL`` environment variable, falling back to
+    ``http://localhost:8080``. If nothing is listening on the resolved host
+    and port, every collected test is skipped so the suite does not falsely
+    fail when the developer simply forgot to start the server.
+    """
+    url = os.getenv("BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+    if not _server_reachable(url):
+        pytest.skip(
+            f"DNSSEC Validator not reachable at {url}. "
+            "Start the server (python app/app.py) or set BASE_URL.",
+            allow_module_level=False,
+        )
+    return url
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args):  # type: ignore[no-redef]
+    """Tighten the default Playwright browser context for our suite.
+
+    We disable service workers (the app does not use them) and pick a
+    reasonable viewport so screenshots taken on failure are predictable.
+    The ``browser_context_args`` fixture is provided by ``pytest-playwright``;
+    here we just extend it.
+    """
+    return {
+        **browser_context_args,
+        "viewport": {"width": 1280, "height": 800},
+        "ignore_https_errors": True,
+        "service_workers": "block",
+    }
+
+
+@pytest.fixture
+def tlsa_dane_enabled() -> bool:
+    """Return whether the TLSA/DANE UI section is expected to render.
+
+    Mirrors the ``SHOW_VALIDATION_TLSA_DANE`` feature flag consumed by the
+    Flask app. Tests that depend on this flag should skip themselves when
+    it is disabled so the suite remains green in either configuration.
+    """
+    return os.getenv("SHOW_VALIDATION_TLSA_DANE", "false").lower() in {
+        "true",
+        "1",
+        "yes",
+    }

--- a/tests/e2e/test_validation_flow.py
+++ b/tests/e2e/test_validation_flow.py
@@ -1,0 +1,205 @@
+"""End-to-end coverage of the domain validation user flow.
+
+These tests drive the form like a real user would, intercepting the
+``/api/validate/<domain>`` request so the suite stays deterministic and
+independent of live DNSSEC infrastructure. A separate test exercises the
+TLSA/DANE section, which is gated by the ``SHOW_VALIDATION_TLSA_DANE``
+feature flag.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+playwright_sync_api = pytest.importorskip(
+    "playwright.sync_api",
+    reason="Install requirements-e2e.txt to run the Playwright suite.",
+)
+
+Page = playwright_sync_api.Page  # type: ignore[attr-defined]
+Route = playwright_sync_api.Route  # type: ignore[attr-defined]
+expect = playwright_sync_api.expect  # type: ignore[attr-defined]
+
+
+def _success_payload(domain: str, include_tlsa: bool = False) -> dict:
+    """Return a synthetic but realistic ``/api/validate`` success body."""
+    payload = {
+        "domain": domain,
+        "status": "valid",
+        "validation_time": "2026-05-16T12:00:00Z",
+        "chain_of_trust": [
+            {
+                "zone": ".",
+                "status": "valid",
+                "algorithm": "ECDSAP256SHA256",
+                "key_tag": "20326",
+            },
+            {
+                "zone": "dk",
+                "status": "valid",
+                "algorithm": "RSASHA256",
+                "key_tag": "12345",
+            },
+            {
+                "zone": domain,
+                "status": "valid",
+                "algorithm": "ECDSAP256SHA256",
+                "key_tag": "67890",
+            },
+        ],
+        "records": {
+            "dnskey": [
+                {
+                    "zone": domain,
+                    "algorithm": "ECDSAP256SHA256",
+                    "key_tag": "67890",
+                    "flags": "257",
+                }
+            ]
+        },
+        "errors": [],
+    }
+    if include_tlsa:
+        payload["tlsa_summary"] = {
+            "status": "valid",
+            "records_found": 1,
+            "dane_status": "secure",
+            "message": "TLSA record matches presented certificate.",
+        }
+    return payload
+
+
+def _install_mock(page: Page, base_url: str, payload: dict) -> None:
+    """Route the validation API call to a static JSON payload."""
+    pattern = re.compile(re.escape(base_url) + r"/api/validate/.+")
+
+    def handler(route: Route) -> None:
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        )
+
+    page.route(pattern, handler)
+
+
+@pytest.mark.e2e
+def test_validation_flow_renders_chain_of_trust(page: Page, base_url: str) -> None:
+    """Submitting a domain should render status, chain of trust and DNSKEYs."""
+    domain = "bondit.dk"
+    _install_mock(page, base_url, _success_payload(domain))
+
+    page.goto(f"{base_url}/")
+    page.locator("#domain-input").fill(domain)
+    page.locator("#dnssec-form button[type='submit']").click()
+
+    results = page.locator("#results-container")
+    expect(results).to_contain_text(f"Validation Results for {domain}", timeout=10_000)
+    expect(results.locator("span.status-valid").first).to_contain_text("VALID")
+    expect(results).to_contain_text("Chain of Trust")
+    expect(results.locator(".chain-item")).to_have_count(4)
+    expect(results).to_contain_text("DNSKEY Records")
+    expect(results).to_contain_text("View Detailed Analysis")
+
+
+@pytest.mark.e2e
+def test_validation_flow_normalizes_url_input(page: Page, base_url: str) -> None:
+    """The client must strip ``https://`` / ``www.`` before calling the API."""
+    domain = "bondit.dk"
+    captured: list[str] = []
+
+    def handler(route: Route) -> None:
+        captured.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_success_payload(domain)),
+        )
+
+    page.route(re.compile(r".+/api/validate/.+"), handler)
+
+    page.goto(f"{base_url}/")
+    page.locator("#domain-input").fill("https://www.BondIT.dk/path?x=1")
+    page.locator("#dnssec-form button[type='submit']").click()
+
+    page.wait_for_function(
+        "() => document.querySelector('#results-container').innerText"
+        ".includes('Validation Results for')",
+        timeout=10_000,
+    )
+
+    assert captured, "Validation API was never called"
+    assert captured[-1].endswith(
+        "/api/validate/bondit.dk"
+    ), f"Expected normalized domain in API URL, got: {captured[-1]}"
+
+
+@pytest.mark.e2e
+def test_validation_flow_displays_api_errors(page: Page, base_url: str) -> None:
+    """A non-2xx API response must surface as a human-readable error."""
+    page.route(
+        re.compile(r".+/api/validate/.+"),
+        lambda route: route.fulfill(
+            status=500,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "domain": "broken.example",
+                    "status": "error",
+                    "validation_time": "2026-05-16T12:00:00Z",
+                    "chain_of_trust": [],
+                    "errors": ["Upstream DNS resolver timed out"],
+                }
+            ),
+        ),
+    )
+
+    page.goto(f"{base_url}/")
+    page.locator("#domain-input").fill("broken.example")
+    page.locator("#dnssec-form button[type='submit']").click()
+
+    results = page.locator("#results-container")
+    expect(results).to_contain_text("ERROR", timeout=10_000)
+    expect(results).to_contain_text("Upstream DNS resolver timed out")
+
+
+@pytest.mark.e2e
+def test_validation_flow_handles_network_failure(page: Page, base_url: str) -> None:
+    """If the fetch itself fails the UI must display an error message."""
+    page.route(
+        re.compile(r".+/api/validate/.+"),
+        lambda route: route.abort("failed"),
+    )
+
+    page.goto(f"{base_url}/")
+    page.locator("#domain-input").fill("offline.example")
+    page.locator("#dnssec-form button[type='submit']").click()
+
+    expect(page.locator("#results-container")).to_contain_text("Error:", timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_tlsa_dane_section_visibility_matches_feature_flag(
+    page: Page, base_url: str, tlsa_dane_enabled: bool
+) -> None:
+    """The TLSA/DANE section must only render when the feature flag is on."""
+    domain = "bondit.dk"
+    _install_mock(page, base_url, _success_payload(domain, include_tlsa=True))
+
+    page.goto(f"{base_url}/")
+    page.locator("#domain-input").fill(domain)
+    page.locator("#dnssec-form button[type='submit']").click()
+
+    results = page.locator("#results-container")
+    expect(results).to_contain_text(f"Validation Results for {domain}", timeout=10_000)
+
+    tlsa_heading = results.get_by_role("heading", name=re.compile(r"TLSA/DANE"))
+
+    if tlsa_dane_enabled:
+        expect(tlsa_heading).to_be_visible()
+        expect(results).to_contain_text("DANE Status:")
+    else:
+        expect(tlsa_heading).to_have_count(0)

--- a/tests/e2e/test_web_ui.py
+++ b/tests/e2e/test_web_ui.py
@@ -1,0 +1,100 @@
+"""Smoke and structural checks for the DNSSEC Validator web UI.
+
+These tests verify that the main page renders the expected controls, that
+navigation links resolve, and that the Swagger UI is reachable. They do not
+trigger DNS validation; for that flow see ``test_validation_flow.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+playwright_sync_api = pytest.importorskip(
+    "playwright.sync_api",
+    reason="Install requirements-e2e.txt to run the Playwright suite.",
+)
+
+Page = playwright_sync_api.Page  # type: ignore[attr-defined]
+expect = playwright_sync_api.expect  # type: ignore[attr-defined]
+
+
+@pytest.mark.e2e
+def test_index_page_renders_core_controls(page: Page, base_url: str) -> None:
+    """The landing page must expose the domain input and submit button."""
+    page.goto(f"{base_url}/")
+
+    expect(page).to_have_title("DNSSEC Validator")
+    expect(page.locator("h1")).to_contain_text("DNSSEC Validator")
+
+    domain_input = page.locator("#domain-input")
+    expect(domain_input).to_be_visible()
+    # Placeholder is set in the template; assert it mentions a domain example.
+    expect(domain_input).to_have_attribute(
+        "placeholder", re.compile(r"domain", re.IGNORECASE)
+    )
+    # The required attribute must be present so the browser blocks empty
+    # submissions before they ever hit the API.
+    expect(domain_input).to_have_attribute("required", "")
+
+    submit = page.locator("#dnssec-form button[type='submit']")
+    expect(submit).to_be_visible()
+    expect(submit).to_have_text("Validate DNSSEC")
+
+
+@pytest.mark.e2e
+def test_navigation_links_present(page: Page, base_url: str) -> None:
+    """Analytics and API Docs links must be wired up on the header."""
+    page.goto(f"{base_url}/")
+
+    analytics_link = page.locator("nav a[href='/stats']")
+    api_docs_link = page.locator("nav a[href='/api/docs/']")
+
+    expect(analytics_link).to_be_visible()
+    expect(analytics_link).to_contain_text("Analytics")
+    expect(api_docs_link).to_be_visible()
+    expect(api_docs_link).to_contain_text("API Docs")
+
+
+@pytest.mark.e2e
+def test_api_docs_page_loads_swagger_ui(page: Page, base_url: str) -> None:
+    """The Swagger UI served by Flask-RESTX should render its container."""
+    response = page.goto(f"{base_url}/api/docs/")
+    assert response is not None
+    assert response.ok, f"API docs returned HTTP {response.status}"
+
+    # Flask-RESTX renders Swagger UI inside a #swagger-ui div, and the
+    # toolbar typically contains the literal text "Swagger".
+    expect(page.locator("#swagger-ui")).to_be_visible(timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_health_endpoint_returns_ok(page: Page, base_url: str) -> None:
+    """A quick HTTP-level sanity check via Playwright's request API."""
+    response = page.request.get(f"{base_url}/health/simple")
+    assert response.ok, f"/health/simple returned HTTP {response.status}"
+
+
+@pytest.mark.e2e
+def test_empty_submission_is_blocked_by_browser(page: Page, base_url: str) -> None:
+    """Submitting an empty form must not trigger a network request.
+
+    The ``required`` attribute on ``#domain-input`` should keep the browser
+    from posting; we assert by listening for any ``/api/validate/`` request
+    in the next short window.
+    """
+    page.goto(f"{base_url}/")
+
+    requests: list[str] = []
+    page.on(
+        "request",
+        lambda req: (requests.append(req.url) if "/api/validate/" in req.url else None),
+    )
+
+    page.locator("#dnssec-form button[type='submit']").click()
+    page.wait_for_timeout(500)
+
+    assert not requests, (
+        "Empty form submission unexpectedly fired a validation request: " f"{requests}"
+    )


### PR DESCRIPTION
## Summary
- New \`tests/e2e/\` directory with Playwright-based browser tests for the validation flow and UI smoke checks.
- \`tests/e2e/conftest.py\` probes \`BASE_URL\` (default \`http://localhost:8080\`) and skips the suite when no server is reachable — so the existing pytest run is never affected by Playwright absence.
- \`test_validation_flow.py\` mocks the \`/api/validate\` response with realistic payloads and asserts the rendered chain of trust + TLSA section (gated by \`SHOW_VALIDATION_TLSA_DANE\`).
- \`test_web_ui.py\` covers static page smoke checks (form, nav links, \`/api/docs/\`).
- \`pytest.ini\` excludes \`tests/e2e/\` from the default collection via \`--ignore\` and \`norecursedirs\`; \`@pytest.mark.e2e\` marker registered.
- Heavyweight Playwright dependencies live in \`requirements-e2e.txt\` to keep the default install lean.

Closes #114.

## Caveat
The issue checklist mentions updating \`WARP.md\`. WARP.md is gitignored in this repo (per \`.gitignore:133\`) so the change can't ship via the PR. Equivalent setup instructions live in \`tests/e2e/README.md\`.

## Test plan
- [x] Default suite: 175 passing, \`tests/e2e/\` correctly **not** collected
- [x] black formatted, pylint 9.99/10
- [ ] Manual opt-in: \`pip install -r requirements-e2e.txt && playwright install chromium && python app/app.py &\` then \`pytest tests/e2e --no-cov -p no:cacheprovider\`