### PR TITLE
Bump codecov/codecov-action v5 -> v6 (drop Node 20)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,7 @@ jobs:
           python -m pytest tests/ --cov=app --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -303,7 +303,7 @@ jobs:
           python -m pytest tests/ --cov=app --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Bumps \`codecov/codecov-action\` from \`v5\` to \`v6\` in both \`pr-quality-gate.yml\` and \`docker-publish.yml\`.

## Why
GitHub now warns on \`actions/github-script@v7.0.1\` (Node 20), pulled in transitively by \`codecov-action@v5\`. Per [GitHub's deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 runners are removed on 2026-09-16, with forced Node 24 starting 2026-06-02.

\`codecov-action@v6.0.0\` is the Node 24 release — it bumps the transitive \`github-script\` to v8.

## Test plan
- [x] Both workflow files updated
- [ ] CI run on this PR confirms the deprecation warning is gone on the codecov upload step