### PR TITLE
chore(deps): bundle Dependabot sweep + add grouping config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,20 @@ updates:
     commit-message:
       prefix: "chore(deps):"
       include: "scope"
+    groups:
+      # Bundle patch + minor bumps into a single weekly PR per category.
+      # Security advisories always come as separate PRs (Dependabot default).
+      # Majors stay separate so they get a proper review.
+      pip-production:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      pip-development:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -37,3 +51,10 @@ updates:
     commit-message:
       prefix: "chore(deps):"
       include: "scope"
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -12,5 +12,5 @@
 # http://localhost:8080):
 #   pytest tests/e2e --no-cov -p no:cacheprovider
 
-playwright>=1.49.0,<2.0.0
-pytest-playwright>=0.7.0,<1.0.0
+playwright>=1.60.0,<2.0.0
+pytest-playwright>=0.8.0,<1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@ cryptography>=48.0.0
 gunicorn==26.0.0
 flask-cors>=6.0.2
 flask-limiter==4.1.1
-requests==2.34.0
+requests==2.34.2
 python-dateutil==2.9.0.post0
 flask-restx>=1.3.2
 flask-talisman>=1.1.0
 flask-caching==2.4.0
 psutil>=7.2.2
 influxdb-client>=1.50.0
-click>=8.3.3
-idna>=3.11
+click>=8.4.1
+idna>=3.15
 
 # Testing dependencies
 pytest>=9.0.3


### PR DESCRIPTION
## Why

Five Dependabot PRs were queued on this repo. Bundling the safe patch + minor bumps into one PR keeps CI runs and reviewer noise down, and adds `groups:` to `.github/dependabot.yml` so this stops piling up weekly.

## Bundled bumps (supersedes #158, #159, #160, #161, #162)

`requirements.txt`:
| Package | From | To |
|---|---|---|
| requests | 2.34.0 | 2.34.2 |
| click | >=8.3.3 | >=8.4.1 |
| idna | >=3.11 | >=3.15 |

`requirements-e2e.txt`:
| Package | From | To |
|---|---|---|
| playwright | >=1.49.0,<2.0.0 | >=1.60.0,<2.0.0 |
| pytest-playwright | >=0.7.0,<1.0.0 | >=0.8.0,<1.0.0 |

## Verification

- `pip install -r requirements.txt` — clean
- `pytest --no-cov` — **246/246 passed** (e2e suite excluded per pytest.ini default)

## 🧱 Dependabot grouping

Added `groups:` config — future weekly runs will produce:
- 1 PR for pip production (minor + patch)
- 1 PR for pip development (minor + patch)
- 1 PR for docker (minor + patch)

Majors and security advisories still arrive as individual PRs.

## Closes

#157 (weekly maintenance report)
Supersedes #158, #159, #160, #161, #162
