### PR TITLE
chore(deps): bump idna from 3.15 to 3.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ flask-caching==2.4.0
 psutil>=7.2.2
 influxdb-client>=1.50.0
 click>=8.4.1
-idna>=3.15
+idna>=3.16
 
 # Testing dependencies
 pytest>=9.0.3


### PR DESCRIPTION
## Round 2 sweep

Only outstanding bump after round 1 (PR #164) merged. Verified via PyPI that all other deps in requirements.txt are already at latest.

## Verification

- `safety check -r requirements.txt` — clean
- `pytest --no-cov` — **246/246 passed**

## Closes

Supersedes #165